### PR TITLE
FE : Solved scss duplicated(hot fix)

### DIFF
--- a/frontend/src/scss/Layout.scss
+++ b/frontend/src/scss/Layout.scss
@@ -6,8 +6,13 @@
 @import "./base/mixin";
 
 // components scss
+@import "./components/headerLogo";
 @import "./components/sideMenu";
 @import "./components/sideMenuBtn";
+
+body {
+    font-family: "Noto Sans KR", sans-serif;
+}
 
 #wrap {
     display: flex;

--- a/frontend/src/scss/MyPage.scss
+++ b/frontend/src/scss/MyPage.scss
@@ -6,5 +6,4 @@
 @import "./base/mixin";
 
 // components scss
-@import "./components/headerLogo";
 @import "./components/myPage";

--- a/frontend/src/scss/ProductDetail.scss
+++ b/frontend/src/scss/ProductDetail.scss
@@ -6,9 +6,6 @@
 @import "./base/mixin";
 
 // components scss
-@import "./components/search";
-@import "./components/headerLogo";
-@import "./Layout";
 @import "./components/detail";
 @import "./components/martLabel";
 

--- a/frontend/src/scss/ProductList.scss
+++ b/frontend/src/scss/ProductList.scss
@@ -7,7 +7,6 @@
 
 // components scss
 @import "./components/product";
-@import "./components/headerLogo";
 @import "./components/martLabel";
 
 .product-list-container {

--- a/frontend/src/scss/base/_base.scss
+++ b/frontend/src/scss/base/_base.scss
@@ -2,7 +2,3 @@
 
 /* import font */
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap');
-
-body {
-  font-family: "Noto Sans KR", sans-serif;
-}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42960217/125588332-86dc92fe-6240-4b91-b2e1-f6c01eb60e9f.png)

- 기존 구조 : scss 중복 호출 문제 존재

![image](https://user-images.githubusercontent.com/42960217/125588474-c1552950-1e4a-46d4-8930-6386026090aa.png)

- 개선
  - 다양한 페이지에서 같은 scss 컴포넌트를 import하면 이러한 문제가 생기는 것을 발견
    - 따라서 default scss인 base, variable, mixin에는 style 요소가 들어가면 안됨
      - base에 있던 style 요소는 Layout.scss로 옮김
  - headerLogo 같은 여러곳에서 재사용 가능한 컴포넌트의 경우 어떤 페이지에도 존재하는 Layout에서 import하도록 합시다!
  - 그리고 Layout.scss는 Layout 컴포넌트가 모든 페이지에 적용되기때문에 따로 다른 페이지 scss에서 import하지 않아도 됩니다!