### PR TITLE
FE : Product List => Detail (Redux)

### DIFF
--- a/frontend/src/Components/Product/ProductPresenter.js
+++ b/frontend/src/Components/Product/ProductPresenter.js
@@ -1,6 +1,9 @@
 import React from "react";
+import { Link } from "react-router-dom";
+import { useDispatch } from "react-redux";
 import { Grid, Button } from "@material-ui/core";
 import { CU, SEVEN_ELEVEN, GS25, EMART24 } from "../Util/Constant";
+import { selectProduct } from "../../Store/Actions/productAction";
 
 const ProductPresenter = ({
   id,
@@ -11,6 +14,8 @@ const ProductPresenter = ({
   sale_price,
 }) => {
   var martClass = "product-info-mart";
+  const productInfo = { id: id, mart_name: mart_name, product_name: product_name, product_image: product_image, original_price: original_price, sale_price: sale_price };
+  const dispatch = useDispatch();
   switch (mart_name) {
     case "CU":
       martClass = `${martClass} product-info-mart-${CU}`;
@@ -27,6 +32,9 @@ const ProductPresenter = ({
     default:
       break;
   }
+  const onClick = () => {
+    dispatch(selectProduct(productInfo));
+  }
   return (
     <Grid className="product-container">
       <Grid className="product-image-container">
@@ -42,13 +50,14 @@ const ProductPresenter = ({
         <span className="product-info-text"> {product_name} </span>
         <span className={martClass}> {mart_name} </span>
       </Grid>
-      <Button
-        className="product-button"
-        variant="contained"
-        href={`/list/${id}`}
-      >
-        자세히
-      </Button>
+      <Link className="product-button" to={`/list/${id}`}>
+        <Button
+          onClick={onClick}
+          variant="contained"
+        >
+          자세히
+        </Button>
+      </Link>
     </Grid>
   );
 };

--- a/frontend/src/Components/Product/ProductPresenter.js
+++ b/frontend/src/Components/Product/ProductPresenter.js
@@ -14,7 +14,14 @@ const ProductPresenter = ({
   sale_price,
 }) => {
   var martClass = "product-info-mart";
-  const productInfo = { id: id, mart_name: mart_name, product_name: product_name, product_image: product_image, original_price: original_price, sale_price: sale_price };
+  const productInfo = {
+    id: id,
+    mart_name: mart_name,
+    product_name: product_name,
+    product_image: product_image,
+    original_price: original_price,
+    sale_price: sale_price,
+  };
   const dispatch = useDispatch();
   switch (mart_name) {
     case "CU":
@@ -34,7 +41,7 @@ const ProductPresenter = ({
   }
   const onClick = () => {
     dispatch(selectProduct(productInfo));
-  }
+  };
   return (
     <Grid className="product-container">
       <Grid className="product-image-container">
@@ -51,10 +58,7 @@ const ProductPresenter = ({
         <span className={martClass}> {mart_name} </span>
       </Grid>
       <Link className="product-button" to={`/list/${id}`}>
-        <Button
-          onClick={onClick}
-          variant="contained"
-        >
+        <Button onClick={onClick} variant="contained">
           자세히
         </Button>
       </Link>

--- a/frontend/src/Components/ProductDetail/ProductDetailContainer.js
+++ b/frontend/src/Components/ProductDetail/ProductDetailContainer.js
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import ProductDetailPresenter from "./ProductDetailPresenter";
 
 const ProductDetailContainer = () => {
-  const item = useSelector(state => state.productReducer.product);
+  const item = useSelector((state) => state.productReducer.product);
   /* TODO : store와 url끝의 martid가 일치하지 않을 경우, API 호출해서 갱신 */
   let sale_percent = Math.round((item.sale_price * 100) / item.original_price);
   return <ProductDetailPresenter item={item} sale_percent={sale_percent} />;

--- a/frontend/src/Components/ProductDetail/ProductDetailContainer.js
+++ b/frontend/src/Components/ProductDetail/ProductDetailContainer.js
@@ -1,24 +1,11 @@
 import React from "react";
+import { useSelector } from "react-redux";
 
 import ProductDetailPresenter from "./ProductDetailPresenter";
 
 const ProductDetailContainer = () => {
-  const item = {
-    "product_id": 1,
-    "mart_name": "SEVEN11",
-    "product_name": "르구르망)오레오밀크스낵30g",
-    "product_image": "https://www.7-eleven.co.kr/upload/product/0000090/426278.1.jpg",
-    "original_price": 2310,
-    "sale_price": 1000,
-    "sale_start_day": "2021-7-1",
-    "sale_end_day": "2021-7-31",
-    "sale_category": "OnePlusOne",
-    "gift_name": "",
-    "gift_image": "",
-    "gift_price": "",
-    "created_day": "2021-7-5",
-  };
-
+  const item = useSelector(state => state.productReducer.product);
+  /* TODO : store와 url끝의 martid가 일치하지 않을 경우, API 호출해서 갱신 */
   let sale_percent = Math.round((item.sale_price * 100) / item.original_price);
   return <ProductDetailPresenter item={item} sale_percent={sale_percent} />;
 };

--- a/frontend/src/Store/Actions/productAction.js
+++ b/frontend/src/Store/Actions/productAction.js
@@ -1,8 +1,6 @@
-import {
-  SELECT_PRODUCT
-} from "./type";
+import { SELECT_PRODUCT } from "./type";
 
-export const selectProduct = ( product_info ) => {
+export const selectProduct = (product_info) => {
   return {
     type: SELECT_PRODUCT,
     payload: product_info,

--- a/frontend/src/Store/Actions/productAction.js
+++ b/frontend/src/Store/Actions/productAction.js
@@ -1,0 +1,10 @@
+import {
+  SELECT_PRODUCT
+} from "./type";
+
+export const selectProduct = ( product_info ) => {
+  return {
+    type: SELECT_PRODUCT,
+    payload: product_info,
+  };
+};

--- a/frontend/src/Store/Actions/type.js
+++ b/frontend/src/Store/Actions/type.js
@@ -3,3 +3,4 @@ export const LOGOUT_USER = "Logout_user";
 export const AUTH_USER = "Auth_user";
 export const WITHDRAW_USER = "Withdraw_user";
 export const GET_USER_INFO = "Get_user_info";
+export const SELECT_PRODUCT = "Select_product";

--- a/frontend/src/Store/Reducers/index.js
+++ b/frontend/src/Store/Reducers/index.js
@@ -1,11 +1,13 @@
 import { combineReducers } from "redux";
 import userReducer from "./userReducer";
+import productReducer from "./productReducer";
 
 /**
  * if other Reducer exist, add reducer
  */
 const rootReducer = combineReducers({
   userReducer,
+  productReducer,
 });
 
 export default rootReducer;

--- a/frontend/src/Store/Reducers/productReducer.js
+++ b/frontend/src/Store/Reducers/productReducer.js
@@ -1,0 +1,15 @@
+import {
+  SELECT_PRODUCT
+} from "../Actions/type";
+
+const productReducer = (state = {}, action) => {
+  switch (action.type) {
+    case SELECT_PRODUCT:
+      console.log(action.payload);
+      return { ...state, product: action.payload };
+    default:
+      return state;
+  }
+};
+
+export default productReducer;

--- a/frontend/src/Store/Reducers/productReducer.js
+++ b/frontend/src/Store/Reducers/productReducer.js
@@ -1,6 +1,4 @@
-import {
-  SELECT_PRODUCT
-} from "../Actions/type";
+import { SELECT_PRODUCT } from "../Actions/type";
 
 const productReducer = (state = {}, action) => {
   switch (action.type) {

--- a/frontend/src/Store/store.js
+++ b/frontend/src/Store/store.js
@@ -1,1 +1,7 @@
 // Redux
+import { createStore } from "redux";
+import rootReducer from "./Reducers";
+
+const store = createStore(rootReducer);
+
+export default store;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,11 +4,8 @@ import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 
-import { createStore } from "redux";
 import { Provider } from "react-redux";
-import Reducers from "./Store/Reducers";
-
-const store = createStore(Reducers);
+import store from "./Store/store";
 
 ReactDOM.render(
   <React.StrictMode>

--- a/frontend/src/scss/Layout.scss
+++ b/frontend/src/scss/Layout.scss
@@ -28,3 +28,9 @@ body {
         background-color: #e7e7e7;
     }
 }
+
+.header-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}

--- a/frontend/src/scss/ProductDetail.scss
+++ b/frontend/src/scss/ProductDetail.scss
@@ -10,7 +10,7 @@
 @import "./components/martLabel";
 
 .product-detail-container {
-  height: 100%;
+  height: 80%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/frontend/src/scss/components/_detail.scss
+++ b/frontend/src/scss/components/_detail.scss
@@ -1,7 +1,7 @@
 .item-container {
   margin: 0 auto;
   width: 85%;
-  height: 100%;
+  height: 90%;
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
@@ -58,7 +58,7 @@
 }
 
 .bag-button-container {
-  height: 8%;
+  height: 10%;
   border-top: 1px solid black;
   display: flex;
   align-items: center;

--- a/frontend/src/scss/components/_product.scss
+++ b/frontend/src/scss/components/_product.scss
@@ -6,6 +6,9 @@
     height: 10vh;
   }
   border-bottom: 2px solid #cdcdcd;
+  a {
+    text-decoration: none;
+  }
 }
 .product-image-container {
   display: flex;


### PR DESCRIPTION
### React-Redux

- Product List 페이지에서 Detail 페이지로 이동할 때, Redux를 사용

- '자세히' 버튼을 눌렀을 때 `useDispatch()`, Detail 페이지를 열 때 `useSelector()`로 불러옴

- - -

### Issue

- redux issue : 기존 코드에서 아무리 `useDispatch()`를 해도 state 저장이 안되던 issue가 있었는데, 페이지 이동을 할 때 `<Button />`이 아니라 `<Link />`를 사용하니까 잘 되네요..

- scss issue : product의 원본 이미지 비율에 따라 detail 페이지가 잘리거나 스크롤이 생기는 issue가 있어 값들을 살짝 수정했습니다.