### PR TITLE
다중 마트 검색 페이징

### DIFF
--- a/backend/src/main/java/com/modimoa/backend/controller/ProductController.java
+++ b/backend/src/main/java/com/modimoa/backend/controller/ProductController.java
@@ -6,6 +6,8 @@ import com.modimoa.backend.service.ProductService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,14 +30,13 @@ public class ProductController {
 
     // 특정 마트 물건 가져오는 기능
     @GetMapping("{mart}/{q}")
-    public Page<Product> getFilteredProduct(@PathVariable Mart mart, @PathVariable String q, Pageable pageable){
+    public Page<Product> getFilteredProduct(@PathVariable String mart, @PathVariable String q, Pageable pageable){
         return productService.getFilteredProduct(mart, q, pageable);
     }
 
     // 정렬기준
         // 할인된가격순(salePrice)
         // 이름순(productName)
-        // 할인률
     // 필터링
         // 이름(q)
         // 마트(mart)

--- a/backend/src/main/java/com/modimoa/backend/domain/Product.java
+++ b/backend/src/main/java/com/modimoa/backend/domain/Product.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
-public class Product extends BaseTimeEntity implements Serializable {
+public class Product extends BaseTimeEntity implements Serializable{
 
     public static final long serialVersionUID = -6184044926029805156L;
 
@@ -69,4 +69,5 @@ public class Product extends BaseTimeEntity implements Serializable {
     public long getProductId() {
         return productId;
     }
+
 }

--- a/backend/src/main/java/com/modimoa/backend/repository/ProductRepository.java
+++ b/backend/src/main/java/com/modimoa/backend/repository/ProductRepository.java
@@ -12,5 +12,5 @@ import java.util.List;
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    Page<Product> findByMartNameAndProductNameContaining(Mart mart, String q, Pageable pageable);
+    List<Product> findByMartNameAndProductNameContaining(Mart mart, String q);
 }


### PR DESCRIPTION
단일 마트 검색 시 JPA 내장 기능으로 페이징, 쿼리, 정렬 등 구현되지만 다중 마트 검색 시 내장 기능 사용 안되는 이슈
- 마트 4개에 대해 쿼리 Containing 옵션으로 검색 수행
- 리스트 객체 만들어서 페이지 객체에 넣음, 페이지 start end 값 넣어서 조건에 맞는 페이지 반환
- 정렬 기능은 Comparator를 ProductNameComparator, ProductPriceComparator로 override해서 구현

여러 마트 검색했을 때 페이징 처리 되도록 코드 수정!