### PR TITLE
FE : Search Func

### DIFF
--- a/frontend/src/Components/Header/HeaderContainer.js
+++ b/frontend/src/Components/Header/HeaderContainer.js
@@ -2,9 +2,9 @@ import React from "react";
 
 import HeaderPresenter from "./HeaderPresenter";
 
-const HeaderContainer = ({ children, setFinalSearchKeyword }) => {
+const HeaderContainer = ({ children }) => {
   return (
-    <HeaderPresenter setFinalSearchKeyword={setFinalSearchKeyword}>
+    <HeaderPresenter>
       {children}
     </HeaderPresenter>
   );

--- a/frontend/src/Components/Header/HeaderContainer.js
+++ b/frontend/src/Components/Header/HeaderContainer.js
@@ -3,11 +3,7 @@ import React from "react";
 import HeaderPresenter from "./HeaderPresenter";
 
 const HeaderContainer = ({ children }) => {
-  return (
-    <HeaderPresenter>
-      {children}
-    </HeaderPresenter>
-  );
+  return <HeaderPresenter>{children}</HeaderPresenter>;
 };
 
 export default HeaderContainer;

--- a/frontend/src/Components/Header/HeaderPresenter.js
+++ b/frontend/src/Components/Header/HeaderPresenter.js
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import { TextField } from "@material-ui/core";
 import { Grid } from "@material-ui/core";
 
-const HeaderPresenter = ({ setFinalSearchKeyword, children }) => {
+const HeaderPresenter = ({ children }) => {
   const LogoLong = () => {
     return (
       <Link to="/main">
@@ -21,11 +21,15 @@ const HeaderPresenter = ({ setFinalSearchKeyword, children }) => {
 
   const SearchBar = () => {
     const [searchKeyword, setSearchKeyword] = useState("");
+    const history = useHistory();
     const handleChange = (e) => {
       setSearchKeyword(e.target.value);
     };
     const onClickSearch = () => {
-      setFinalSearchKeyword(searchKeyword);
+      if (searchKeyword)
+        history.push({pathname: "/list", search: `?keyword=${searchKeyword}`});
+      else
+        alert("검색어를 입력해주세요");
     };
     const onEnterPress = (e) => {
       if (e.key === "Enter") {

--- a/frontend/src/Components/Header/HeaderPresenter.js
+++ b/frontend/src/Components/Header/HeaderPresenter.js
@@ -27,9 +27,11 @@ const HeaderPresenter = ({ children }) => {
     };
     const onClickSearch = () => {
       if (searchKeyword)
-        history.push({pathname: "/list", search: `?keyword=${searchKeyword}`});
-      else
-        alert("검색어를 입력해주세요");
+        history.push({
+          pathname: "/list",
+          search: `?keyword=${searchKeyword}`,
+        });
+      else alert("검색어를 입력해주세요");
     };
     const onEnterPress = (e) => {
       if (e.key === "Enter") {

--- a/frontend/src/Components/Main/MainPresenter.js
+++ b/frontend/src/Components/Main/MainPresenter.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { useHistory } from "react-router-dom";
 import { Button } from "@material-ui/core";
 import { TextField } from "@material-ui/core";
 import {
@@ -32,8 +33,23 @@ const MainPresenter = ({
   handleChange,
   martList,
   setMartList,
-  handleLogoClick,
+  handleLogoClick
 }) => {
+  const history = useHistory(); 
+
+  const onClickSearch = () => {
+    if (searchKeyword)
+      history.push({pathname: "/list", search: `?keyword=${searchKeyword}`});
+    else
+      alert("검색어를 입력해주세요");
+  };
+
+  const onEnterPress = (e) => {
+    if (e.key === "Enter") {
+      onClickSearch();
+    }
+  };
+
   return (
     <div className="content-container">
       <div className="content-beer">
@@ -55,13 +71,14 @@ const MainPresenter = ({
         <TextField
           value={searchKeyword}
           onChange={handleChange}
+          onKeyPress={onEnterPress}
           label="검색어를 입력하세요"
           InputLabelProps={{
             shrink: true,
           }}
           variant="outlined"
         />
-        <span className="search-btn">
+        <span className="search-btn" onClick={onClickSearch}>
           <img
             className="search-icon"
             src={`/img/search_icon.png`}

--- a/frontend/src/Components/Main/MainPresenter.js
+++ b/frontend/src/Components/Main/MainPresenter.js
@@ -33,15 +33,14 @@ const MainPresenter = ({
   handleChange,
   martList,
   setMartList,
-  handleLogoClick
+  handleLogoClick,
 }) => {
-  const history = useHistory(); 
+  const history = useHistory();
 
   const onClickSearch = () => {
     if (searchKeyword)
-      history.push({pathname: "/list", search: `?keyword=${searchKeyword}`});
-    else
-      alert("검색어를 입력해주세요");
+      history.push({ pathname: "/list", search: `?keyword=${searchKeyword}` });
+    else alert("검색어를 입력해주세요");
   };
 
   const onEnterPress = (e) => {

--- a/frontend/src/Pages/ProductListPage.js
+++ b/frontend/src/Pages/ProductListPage.js
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 
 import AppBar from "@material-ui/core/AppBar";
 import Tabs from "@material-ui/core/Tabs";
@@ -11,7 +13,6 @@ import MartList from "../Components/MartList";
 
 import "../scss/ProductList.scss";
 import "../scss/MartList.scss";
-import { useSelector } from "react-redux";
 
 const ResultField = ({ searchKeyword }) => {
   let resultText = "";
@@ -33,10 +34,12 @@ const initialState = {
 };
 
 const ProductListPage = () => {
-  const [finalSearchKeyword, setFinalSearchKeyword] = useState("");
   const [sortOption, setSortOption] = useState(0);
   const martList =
     useSelector((state) => state.martReducer.martList) || initialState;
+
+  const location = useLocation();
+  const keyword = (location.search) ? decodeURI(location.search.match(/\?keyword\=(?<keyword>.+)/).groups.keyword) : '';
 
   const SortBar = () => {
     const handleChange = (event, newOption) => {
@@ -58,13 +61,13 @@ const ProductListPage = () => {
   };
   return (
     <Layout>
-      <Header setFinalSearchKeyword={setFinalSearchKeyword}>
+      <Header>
         <MartList martList={martList} />
-        <ResultField searchKeyword={finalSearchKeyword} />
+        <ResultField searchKeyword={keyword} />
         <SortBar />
       </Header>
       <ProductList
-        searchKeyword={finalSearchKeyword}
+        searchKeyword={keyword}
         martList={martList}
         sortOption={sortOption}
       />

--- a/frontend/src/Pages/ProductListPage.js
+++ b/frontend/src/Pages/ProductListPage.js
@@ -39,7 +39,11 @@ const ProductListPage = () => {
     useSelector((state) => state.martReducer.martList) || initialState;
 
   const location = useLocation();
-  const keyword = (location.search) ? decodeURI(location.search.match(/\?keyword\=(?<keyword>.+)/).groups.keyword) : '';
+  const keyword = location.search
+    ? decodeURI(
+        location.search.match(/\?keyword=(?<keyword>.+)/).groups.keyword
+      )
+    : "";
 
   const SortBar = () => {
     const handleChange = (event, newOption) => {


### PR DESCRIPTION
기존 Search 방식 : ProductListPage.js에서 state관리, param으로 각 component에게 전달
=> depth가 깊어짐 + component간 의존성 생김(`ProductListPage`, `Header`, `ResultField`, `ProductList`)

따라서 main에 있는 Search도 구현할 겸, 아예 `useHistory`와 `useLocation`을 이용한 Query String 방식으로 변경함
(`query-string`이라는 파싱 라이브러리가 있다는데 따로 찾아보기 귀찮아서 정규표현식으로 직접 파싱함)
똑같이 `ProductListPage`에서 keyword를 뿌려주지만, `Header`와 다른 component들과의 의존성을 없앰

뒤로 가기로 이전에 했던 검색을 할 수 있다는 점, 페이지 이동이므로 검색어 상태 변경을 따로 감시하지 않아도 알아서 렌더링이 된다는 점에서 장점이 있는 것 같아요

todo : main과 header의 검색 부분 따로 빼놓으면 좋을 것 같음