### PR TITLE
Desktop 메인 페이지 레이아웃 수정

### DIFF
--- a/frontend/src/scss/Layout.scss
+++ b/frontend/src/scss/Layout.scss
@@ -34,7 +34,12 @@ body {
 .header-container {
   display: flex;
   flex-direction: column;
+  align-items: center;
   width: 100%;
+
+  .MuiGrid-root {
+    width: 100%;
+  }
 }
 
 .back-button {

--- a/frontend/src/scss/components/_mainContent.scss
+++ b/frontend/src/scss/components/_mainContent.scss
@@ -1,19 +1,29 @@
 .content-container {
   height: 100%;
   @include desktop {
-    flex: 5;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    align-items: center;
+    padding: 5% 0 5% 0;
     background-color: rgba(0, 0, 0, 0.46);
   }
 
   @include mobile {
     display: flex;
     flex-direction: column;
-    justify-content: flex-end;
+    justify-content: center;
+    align-items: center;
     overflow-y: hidden;
   }
 
   .content-beer {
     @include desktop {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
       background-image: url(https://www.icegif.com/wp-content/uploads/beer-icegif-3.gif);
       background-size: cover;
       text-align: center;
@@ -21,16 +31,13 @@
       color: snow;
 
       .content-description {
-        margin-top: 70px;
-        padding-top: 30px;
         p {
           font-size: 25px;
-          margin-bottom: 0px;
+          margin: 0;
         }
         p:last-child {
           font-size: 120px;
           font-weight: 500;
-          margin: 0px 0px;
           line-height: 1;
         }
       }
@@ -47,6 +54,7 @@
     }
 
     @include mobile {
+      margin-top: 20%;
       height: 30%;
       text-align: center;
       img {
@@ -55,32 +63,44 @@
     }
   }
 
-  .content-search {
-    height: 10%;
-  }
-
-  .content-footer {
+  .content-foot {
     width: 90%;
-    height: 80%;
     display: flex;
-    justify-content: space-evenly;
-  }
-
-  .content-search,
-  .mart {
-    width: 90%;
-    margin: 0 auto;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    @include desktop {
+      gap: 3rem;
+    }
+    @include mobile {
+      gap: 2rem;
+    }
   }
 
   .mart {
     text-align: center;
+
+    @include desktop {
+      width: calc(100% - 2rem);
+      border: 2px solid snow;
+      border-radius: 10px;
+      padding: 1rem;
+      p {
+        color: snow;
+      }
+    }
+
+    @include mobile {
+      width: 100%;
+    }
+
     p {
       @include font-default(700, 1rem);
-      margin: 1rem 0 1rem 0;
+      margin: 0 0 1.5rem 0;
       text-align: left;
-      padding-left: 0.5rem;
-      @include desktop {
-        color: snow;
+
+      @include mobile {
+        margin: 0 0 0.5rem 0;
       }
     }
 
@@ -88,16 +108,16 @@
       display: flex;
       justify-content: space-between;
 
+      .mart-container {
+        padding: 0;
+      }
+
       img {
         background-color: snow;
         filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.5));
         border-radius: 10px;
         max-width: 100%;
       }
-    }
-
-    &:last-child {
-      margin-bottom: 4rem;
     }
   }
 }

--- a/frontend/src/scss/components/_search.scss
+++ b/frontend/src/scss/components/_search.scss
@@ -1,11 +1,13 @@
 .content-search {
   width: 90%;
+  height: 10%;
   display: flex;
-  margin: 0 auto;
+  align-items: center;
+
   .MuiFormControl-root {
     height: 40px;
     width: 100%;
-    padding: 0.3rem;
+    padding: 0.3rem 0.3rem 0.3rem 0;
 
     .MuiInputBase-root {
       height: 100%;
@@ -13,24 +15,79 @@
     }
   }
 
-  .MuiOutlinedInput-root,
-  .MuiOutlinedInput-notchedOutline {
-    border: 2px solid gray;
-  }
-
   label {
-    padding-left: 0.4rem;
+    padding-left: 0;
   }
 
   .search-btn {
-    margin-top: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     height: 40px;
-
     img {
-      height: 35px;
+      height: 30px;
       cursor: pointer;
-      position: relative;
-      top: 11%;
+    }
+  }
+
+  @include desktop() {
+    gap: 10px;
+    .MuiOutlinedInput-root,
+    .MuiOutlinedInput-notchedOutline {
+      border: 2px solid #FAFAFA;
+    }
+    .MuiOutlinedInput-root:hover {
+      .MuiOutlinedInput-notchedOutline {
+        border-color: #FAFAFA;
+      }
+    }
+    .MuiOutlinedInput-root.Mui-focused {
+      .MuiOutlinedInput-notchedOutline {
+        border-color: #FAFAFA;
+      }
+    }
+    .MuiFormLabel-root {
+      color: #FAFAFA;
+    }
+    .MuiFormLabel-root.Mui-focused {
+      color: #FAFAFA;
+    }
+
+    .MuiInputLabel-formControl {
+      transform: translate(0, 24px) scale(1);
+    }
+
+    .search-btn {
+      background-color: #EDEDED;
+      border: 1px solid #FAFAFA;
+      border-radius: 10px;
+      width: 60px;
+      transition: all 0.1s ease-in-out;
+      img {
+        height: 25px;
+      }
+      &:hover {
+        background-color: #FAFAFA;
+      }
+    }
+  }
+
+  @include mobile() {
+
+    .MuiOutlinedInput-root,
+    .MuiOutlinedInput-notchedOutline {
+      border: 2px solid #808080;
+    }
+    .MuiOutlinedInput-root.Mui-focused {
+      .MuiOutlinedInput-notchedOutline {
+        border-color: #666666;
+      }
+    }
+    .MuiFormLabel-root {
+      color: #808080;
+    }
+    .MuiFormLabel-root.Mui-focused {
+      color: #666666;
     }
   }
 }


### PR DESCRIPTION
## 작업 내용

- [x] 메인 페이지 Desktop 버전 레이아웃 수정

## 전달 사항

- 최대한 모바일 레이아웃 안깨지게 하려고 함
- flex를 제대로 활용 못하고 있던 부분이 많음 (물론 제가 짠 것 같음)
- 앞으로 리팩토링 진행하면서 px => rem 통일 + 색깔 변수 `_variables.scss`에 지정해놓고 할 예정

## 궁금한 점

- 원래 material-ui에 있는 `<TextField />`에 포커스를 주면 label이 이동하지 않던가요???

## 스크린샷 (선택)

- 작업 전

![image](https://user-images.githubusercontent.com/42960217/148904378-e06ae8df-9e17-4f69-b58a-b03efc2110ea.png)


- 작업 후

![image](https://user-images.githubusercontent.com/42960217/148904475-432303ca-777b-4eb6-9625-0d69f62e7d8b.png)
