### PR TITLE
장바구니 로직 수정 및 API 수정

### DIFF
--- a/frontend/src/Components/MyBag/BagProductList.js
+++ b/frontend/src/Components/MyBag/BagProductList.js
@@ -1,26 +1,36 @@
-import BagProduct from "./BagProduct";
+import PurchasedBagProduct from "./PurchasedBagProduct";
+import WishBagProduct from "./WishBagProduct";
 
 const BagProductList = ({
-  list,
+  wishList,
+  purchasedList,
   handleBuyClick,
   handleDeleteClick,
-  buyProductName,
   filterOption,
 }) => {
-  return list.map((item) => (
-    <BagProduct
-      key={item.productId}
-      id={item.productId}
-      product_name={item.productName}
-      product_image={item.productImage}
-      original_price={item.originalPrice}
-      sale_price={item.salePrice}
-      handleBuyClick={handleBuyClick}
-      handleDeleteClick={handleDeleteClick}
-      buyProductName={buyProductName}
-      filterOption={filterOption}
-    />
-  ));
+  return filterOption === 0
+    ? wishList.map((item) => (
+        <WishBagProduct
+          key={item.productId}
+          id={item.productId}
+          product_name={item.productName}
+          product_image={item.productImage}
+          product_count={item.productCnt}
+          sale_price={item.salePrice}
+          handleBuyClick={handleBuyClick}
+          handleDeleteClick={handleDeleteClick}
+        />
+      ))
+    : purchasedList.map((item) => (
+        <PurchasedBagProduct
+          key={item.productId}
+          product_name={item.productName}
+          product_image={item.productImage}
+          product_count={item.productCnt}
+          sale_price={item.salePrice}
+          original_price={item.originalPrice}
+        />
+      ));
 };
 
 export default BagProductList;

--- a/frontend/src/Components/MyBag/BagProductList.js
+++ b/frontend/src/Components/MyBag/BagProductList.js
@@ -1,3 +1,4 @@
+import { PURCHASE_OPTION } from "../Util/Constant";
 import PurchasedBagProduct from "./PurchasedBagProduct";
 import WishBagProduct from "./WishBagProduct";
 
@@ -8,7 +9,7 @@ const BagProductList = ({
   handleDeleteClick,
   filterOption,
 }) => {
-  return filterOption === 0
+  return filterOption === PURCHASE_OPTION.BEFORE_PURCHASE
     ? wishList.map((item) => (
         <WishBagProduct
           key={item.productId}

--- a/frontend/src/Components/MyBag/BuyModal/BuyModalContainer.js
+++ b/frontend/src/Components/MyBag/BuyModal/BuyModalContainer.js
@@ -5,10 +5,7 @@ import {
   changeMyBagState,
 } from "../../../Store/Actions/productAction";
 import BuyModalPresenter from "./BuyModalPresenter";
-
-// const BEFORE_PURCHASE = 0;
-const AFTER_PURCHASE = 1;
-// const TIMEOVER_PURCHASE = 2;
+import { AFTER_PURCHASE } from "../../Util/Constant";
 
 const BuyModalContainer = ({
   isOpenModal,

--- a/frontend/src/Components/MyBag/BuyModal/BuyModalContainer.js
+++ b/frontend/src/Components/MyBag/BuyModal/BuyModalContainer.js
@@ -5,7 +5,7 @@ import {
   changeMyBagState,
 } from "../../../Store/Actions/productAction";
 import BuyModalPresenter from "./BuyModalPresenter";
-import { AFTER_PURCHASE } from "../../Util/Constant";
+import { PURCHASE_OPTION } from "../../Util/Constant";
 
 const BuyModalContainer = ({
   isOpenModal,
@@ -46,7 +46,7 @@ const BuyModalContainer = ({
     const changeCntRes = await dispatch(changeMyBagCnt(selectedId, cntBody));
     if (changeCntRes.payload.status === 200) {
       const stateBody = {
-        status: AFTER_PURCHASE,
+        status: PURCHASE_OPTION.AFTER_PURCHASE,
       };
       const res = await dispatch(changeMyBagState(selectedId, stateBody));
       /**

--- a/frontend/src/Components/MyBag/BuyModal/BuyModalContainer.js
+++ b/frontend/src/Components/MyBag/BuyModal/BuyModalContainer.js
@@ -47,7 +47,7 @@ const BuyModalContainer = ({
       count: number,
     };
     const changeCntRes = await dispatch(changeMyBagCnt(selectedId, cntBody));
-    if (changeCntRes.payload.success) {
+    if (changeCntRes.payload.status === 200) {
       const stateBody = {
         status: AFTER_PURCHASE,
       };
@@ -56,7 +56,7 @@ const BuyModalContainer = ({
        * TODO
        * React Toastify 적용
        */
-      if (res.payload.success) {
+      if (res.payload.status === 200) {
         alert("구매가 완료되었습니다.");
       }
     }

--- a/frontend/src/Components/MyBag/BuyModal/BuyModalContainer.js
+++ b/frontend/src/Components/MyBag/BuyModal/BuyModalContainer.js
@@ -12,6 +12,9 @@ const BuyModalContainer = ({
   setIsOpenModal,
   selectedId,
   buyProductName,
+  wishList,
+  purchasedList,
+  setNextList,
 }) => {
   const [productName, setProductName] = useState("");
   const [number, setNumber] = useState(1);
@@ -54,11 +57,21 @@ const BuyModalContainer = ({
        * React Toastify 적용
        */
       if (res.payload.status === 200) {
+        const nextList = [...wishList, ...purchasedList];
+        setNextList(nextList, parseInt(selectedId));
         alert("구매가 완료되었습니다.");
       }
     }
     setIsOpenModal(false);
-  }, [dispatch, number, selectedId, setIsOpenModal]);
+  }, [
+    dispatch,
+    number,
+    purchasedList,
+    selectedId,
+    setIsOpenModal,
+    setNextList,
+    wishList,
+  ]);
 
   useEffect(() => {
     setProductName(buyProductName);

--- a/frontend/src/Components/MyBag/MyBagContainer.js
+++ b/frontend/src/Components/MyBag/MyBagContainer.js
@@ -1,10 +1,11 @@
-import React, { useCallback, useLayoutEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import {
   deleteWishProduct,
   getMyBagList,
 } from "../../Store/Actions/productAction";
 import MyBagPresenter from "./MyBagPresenter";
+import { AFTER_PURCHASE, BEFORE_PURCHASE } from "../Util/Constant";
 
 const MyBagContainer = ({ filterOption }) => {
   const dispatch = useDispatch();
@@ -12,8 +13,15 @@ const MyBagContainer = ({ filterOption }) => {
   const [buyProductName, setBuyProductName] = useState("");
   const [selectedId, setSelectedId] = useState(-1);
   const [isOpenModal, setIsOpenModal] = useState(false);
-  const [myBagList, setMyBagList] = useState([]);
+  const [, setMyBagList] = useState([]);
+  const [wishList, setWishList] = useState([]);
+  const [purchasedList, setPurchasedList] = useState([]);
 
+  /**
+   * TODO
+   * 구매 완료, 삭제 후 리스트 업데이트
+   * 상품 구매 개수 비동기처리
+   */
   const handleBuyClick = useCallback(async (event) => {
     const targetId = event.target.id;
     const words = targetId.split("&");
@@ -40,8 +48,14 @@ const MyBagContainer = ({ filterOption }) => {
       // eslint-disable-next-line no-restricted-globals
       const ans = confirm("정말로 삭제하시겠습니까?");
       if (ans) {
-        const res = dispatch(deleteWishProduct(productId));
-        if (res.payload.success) {
+        const res = await dispatch(deleteWishProduct(productId));
+        if (res.payload.status === 200) {
+          setMyBagList((prevState) =>
+            prevState.filter((item) => item.productId !== productId)
+          );
+          setWishList((prevState) =>
+            prevState.filter((item) => item.productId !== productId)
+          );
           alert("삭제가 완료되었습니다.");
         }
       }
@@ -49,12 +63,29 @@ const MyBagContainer = ({ filterOption }) => {
     [dispatch]
   );
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const getMyBagListFun = async () => {
       const res = await dispatch(getMyBagList());
-
-      if (res.payload.success) {
-        setMyBagList(res.payload.data);
+      if (res.payload.status === 200) {
+        const itemNumberList = res.payload.data;
+        const nextMyBagList = itemNumberList.map((item) => {
+          return {
+            productId: item.product.productId,
+            productName: item.product.productName,
+            productImage: item.product.productImage,
+            originalPrice: item.product.originalPrice,
+            salePrice: item.product.salePrice,
+            productCnt: item.count,
+            status: item.status,
+          };
+        });
+        setMyBagList(nextMyBagList);
+        setPurchasedList(
+          nextMyBagList.filter((item) => item.status === AFTER_PURCHASE)
+        );
+        setWishList(
+          nextMyBagList.filter((item) => item.status === BEFORE_PURCHASE)
+        );
       }
     };
     getMyBagListFun();
@@ -62,7 +93,8 @@ const MyBagContainer = ({ filterOption }) => {
 
   return (
     <MyBagPresenter
-      list={myBagList}
+      wishList={wishList}
+      purchasedList={purchasedList}
       filterOption={filterOption}
       isOpenModal={isOpenModal}
       handleBuyClick={handleBuyClick}

--- a/frontend/src/Components/MyBag/MyBagContainer.js
+++ b/frontend/src/Components/MyBag/MyBagContainer.js
@@ -5,7 +5,7 @@ import {
   getMyBagList,
 } from "../../Store/Actions/productAction";
 import MyBagPresenter from "./MyBagPresenter";
-import { AFTER_PURCHASE, BEFORE_PURCHASE } from "../Util/Constant";
+import { PURCHASE_OPTION } from "../Util/Constant";
 
 const MyBagContainer = ({ filterOption }) => {
   const dispatch = useDispatch();
@@ -81,10 +81,14 @@ const MyBagContainer = ({ filterOption }) => {
         });
         setMyBagList(nextMyBagList);
         setPurchasedList(
-          nextMyBagList.filter((item) => item.status === AFTER_PURCHASE)
+          nextMyBagList.filter(
+            (item) => item.status === PURCHASE_OPTION.AFTER_PURCHASE
+          )
         );
         setWishList(
-          nextMyBagList.filter((item) => item.status === BEFORE_PURCHASE)
+          nextMyBagList.filter(
+            (item) => item.status === PURCHASE_OPTION.BEFORE_PURCHASE
+          )
         );
       }
     };

--- a/frontend/src/Components/MyBag/MyBagPresenter.js
+++ b/frontend/src/Components/MyBag/MyBagPresenter.js
@@ -4,7 +4,8 @@ import BagProductList from "./BagProductList";
 import BagDescription from "./BagDescription";
 
 const MyBagPresenter = ({
-  list,
+  wishList,
+  purchasedList,
   filterOption,
   handleBuyClick,
   isOpenModal,
@@ -17,7 +18,8 @@ const MyBagPresenter = ({
     <main className="my-bag-container">
       {!filterOption && <BagDescription />}
       <BagProductList
-        list={list}
+        wishList={wishList}
+        purchasedList={purchasedList}
         handleBuyClick={handleBuyClick}
         handleDeleteClick={handleDeleteClick}
         buyProductName={buyProductName}

--- a/frontend/src/Components/MyBag/MyBagPresenter.js
+++ b/frontend/src/Components/MyBag/MyBagPresenter.js
@@ -6,6 +6,7 @@ import BagDescription from "./BagDescription";
 const MyBagPresenter = ({
   wishList,
   purchasedList,
+  setNextList,
   filterOption,
   handleBuyClick,
   isOpenModal,
@@ -32,6 +33,9 @@ const MyBagPresenter = ({
           setIsOpenModal={setIsOpenModal}
           selectedId={selectedId}
           buyProductName={buyProductName}
+          wishList={wishList}
+          purchasedList={purchasedList}
+          setNextList={setNextList}
         />
       )}
     </main>

--- a/frontend/src/Components/MyBag/MyBagPresenter.js
+++ b/frontend/src/Components/MyBag/MyBagPresenter.js
@@ -2,6 +2,7 @@ import React from "react";
 import BuyModal from "./BuyModal";
 import BagProductList from "./BagProductList";
 import BagDescription from "./BagDescription";
+import { PURCHASE_OPTION } from "../Util/Constant";
 
 const MyBagPresenter = ({
   wishList,
@@ -17,7 +18,7 @@ const MyBagPresenter = ({
 }) => {
   return (
     <main className="my-bag-container">
-      {!filterOption && <BagDescription />}
+      {filterOption === PURCHASE_OPTION.BEFORE_PURCHASE && <BagDescription />}
       <BagProductList
         wishList={wishList}
         purchasedList={purchasedList}

--- a/frontend/src/Components/MyBag/PurchasedBagProduct.js
+++ b/frontend/src/Components/MyBag/PurchasedBagProduct.js
@@ -1,11 +1,11 @@
 import { Grid } from "@material-ui/core";
-import AddComma from "../Util/AddComma";
+import addComma from "../Util/AddComma";
 
 const PurchasedDisplay = ({ profit }) => {
   return (
     <Grid className="product-state-info-container">
       <Grid className="product-state-info">구매 완료</Grid>
-      <Grid className="product-state-price">{AddComma(profit)}원 이득</Grid>
+      <Grid className="product-state-price">{addComma(profit)}원 이득</Grid>
     </Grid>
   );
 };
@@ -28,7 +28,7 @@ const PurchasedBagProduct = ({
         <span className="product-info-text">{product_name}</span>
         <Grid className="product-info-price-container">
           <span>
-            {AddComma(sale_price)}원 • <b>{AddComma(product_count)}개</b>
+            {addComma(sale_price)}원 • <b>{addComma(product_count)}개</b>
           </span>
         </Grid>
       </Grid>

--- a/frontend/src/Components/MyBag/PurchasedBagProduct.js
+++ b/frontend/src/Components/MyBag/PurchasedBagProduct.js
@@ -1,0 +1,40 @@
+import { Grid } from "@material-ui/core";
+import AddComma from "../Util/AddComma";
+
+const PurchasedDisplay = ({ profit }) => {
+  return (
+    <Grid className="product-state-info-container">
+      <Grid className="product-state-info">구매 완료</Grid>
+      <Grid className="product-state-price">{AddComma(profit)}원 이득</Grid>
+    </Grid>
+  );
+};
+
+const PurchasedBagProduct = ({
+  product_name,
+  product_image,
+  product_count,
+  original_price,
+  sale_price,
+}) => {
+  const profit = (original_price - sale_price) * product_count;
+
+  return (
+    <Grid className="product-container">
+      <Grid className="product-image-container">
+        <img src={product_image} alt={product_name} />
+      </Grid>
+      <Grid className="product-info-container">
+        <span className="product-info-text">{product_name}</span>
+        <Grid className="product-info-price-container">
+          <span>
+            {AddComma(sale_price)}원 • <b>{AddComma(product_count)}개</b>
+          </span>
+        </Grid>
+      </Grid>
+      <PurchasedDisplay profit={profit} />
+    </Grid>
+  );
+};
+
+export default PurchasedBagProduct;

--- a/frontend/src/Components/MyBag/WishBagProduct.js
+++ b/frontend/src/Components/MyBag/WishBagProduct.js
@@ -1,4 +1,5 @@
 import { Grid } from "@material-ui/core";
+import AddComma from "../Util/AddComma";
 
 const WishDisplay = ({
   id,
@@ -27,27 +28,16 @@ const WishDisplay = ({
     </div>
   );
 };
-const PurchasedDisplay = ({ profit }) => {
-  return (
-    <Grid className="product-state-info-container">
-      <Grid className="product-state-info">구매 완료</Grid>
-      <Grid className="product-state-price">{profit}원 이득</Grid>
-    </Grid>
-  );
-};
 
-const BagProduct = ({
+const WishBagProduct = ({
   id,
   product_name,
   product_image,
-  original_price,
   sale_price,
+  product_count,
   handleBuyClick,
   handleDeleteClick,
-  filterOption,
 }) => {
-  const profit = parseInt(original_price) - parseInt(sale_price);
-
   return (
     <Grid className="product-container">
       <Grid className="product-image-container">
@@ -57,22 +47,18 @@ const BagProduct = ({
         <span className="product-info-text"> {product_name} </span>
         <Grid className="product-info-price-container">
           <span>
-            {`${sale_price}원 • `} <b>1개</b>
+            {`${AddComma(sale_price)}원 • `} <b>{product_count}개</b>
           </span>
         </Grid>
       </Grid>
-      {filterOption === 0 ? (
-        <WishDisplay
-          id={id}
-          product_name={product_name}
-          handleBuyClick={handleBuyClick}
-          handleDeleteClick={handleDeleteClick}
-        />
-      ) : (
-        <PurchasedDisplay profit={profit} />
-      )}
+      <WishDisplay
+        id={id}
+        product_name={product_name}
+        handleBuyClick={handleBuyClick}
+        handleDeleteClick={handleDeleteClick}
+      />
     </Grid>
   );
 };
 
-export default BagProduct;
+export default WishBagProduct;

--- a/frontend/src/Components/MyBag/WishBagProduct.js
+++ b/frontend/src/Components/MyBag/WishBagProduct.js
@@ -1,5 +1,5 @@
 import { Grid } from "@material-ui/core";
-import AddComma from "../Util/AddComma";
+import addComma from "../Util/AddComma";
 
 const WishDisplay = ({
   id,
@@ -47,7 +47,7 @@ const WishBagProduct = ({
         <span className="product-info-text"> {product_name} </span>
         <Grid className="product-info-price-container">
           <span>
-            {`${AddComma(sale_price)}원 • `} <b>{product_count}개</b>
+            {`${addComma(sale_price)}원 • `} <b>{product_count}개</b>
           </span>
         </Grid>
       </Grid>

--- a/frontend/src/Components/MyPageContent/MyPagePresenter.js
+++ b/frontend/src/Components/MyPageContent/MyPagePresenter.js
@@ -7,7 +7,7 @@ import Avatar from "@material-ui/core/Avatar";
 import Typography from "@material-ui/core/Typography";
 import CardActions from "@material-ui/core/CardActions";
 import Button from "@material-ui/core/Button";
-import AddComma from "../Util/AddComma";
+import addComma from "../Util/AddComma";
 
 const UserProfile = ({ handleLogout, userInfo, profit }) => {
   return (
@@ -20,7 +20,7 @@ const UserProfile = ({ handleLogout, userInfo, profit }) => {
           {userInfo.user_email}
         </Typography>
         <Typography variant="body1" color="textPrimary" component="p">
-          얼마를 아꼈는가? <b>{AddComma(profit)}원</b>
+          얼마를 아꼈는가? <b>{addComma(profit)}원</b>
         </Typography>
       </CardContent>
       <CardActions>

--- a/frontend/src/Components/MyPageContent/MyPagePresenter.js
+++ b/frontend/src/Components/MyPageContent/MyPagePresenter.js
@@ -7,17 +7,20 @@ import Avatar from "@material-ui/core/Avatar";
 import Typography from "@material-ui/core/Typography";
 import CardActions from "@material-ui/core/CardActions";
 import Button from "@material-ui/core/Button";
+import AddComma from "../Util/AddComma";
 
 const UserProfile = ({ handleLogout, userInfo, profit }) => {
   return (
     <Card>
-      <CardHeader avatar={<Avatar alt="user-image" src={userInfo.image} />} />
+      <CardHeader
+        avatar={<Avatar alt="user-image" src={userInfo.user_image} />}
+      />
       <CardContent>
         <Typography variant="body1" color="textPrimary" component="p">
-          {userInfo.email}
+          {userInfo.user_email}
         </Typography>
         <Typography variant="body1" color="textPrimary" component="p">
-          얼마를 아꼈는가? <b>{profit}원</b>
+          얼마를 아꼈는가? <b>{AddComma(profit)}원</b>
         </Typography>
       </CardContent>
       <CardActions>

--- a/frontend/src/Components/Product/ProductPresenter.js
+++ b/frontend/src/Components/Product/ProductPresenter.js
@@ -4,6 +4,7 @@ import { useDispatch } from "react-redux";
 import { Grid, Button } from "@material-ui/core";
 import { CU, SEVEN_ELEVEN, GS25, EMART24 } from "../Util/Constant";
 import { selectProduct } from "../../Store/Actions/productAction";
+import AddComma from '../Util/AddComma';
 
 const ProductPresenter = ({
   id,
@@ -51,8 +52,8 @@ const ProductPresenter = ({
       <Grid className="product-info-container">
         <Grid className="product-info-price-container">
           <span>
-            {`${sale_price} `}
-            <del>{original_price}</del>
+            {`${AddComma(sale_price)}`}
+            <del>{AddComma(original_price)}</del>
           </span>
         </Grid>
         <span className="product-info-text"> {product_name} </span>

--- a/frontend/src/Components/Product/ProductPresenter.js
+++ b/frontend/src/Components/Product/ProductPresenter.js
@@ -4,7 +4,7 @@ import { useDispatch } from "react-redux";
 import { Grid, Button } from "@material-ui/core";
 import { CU, SEVEN_ELEVEN, GS25, EMART24 } from "../Util/Constant";
 import { selectProduct } from "../../Store/Actions/productAction";
-import AddComma from '../Util/AddComma';
+import addComma from "../Util/AddComma";
 
 const ProductPresenter = ({
   id,
@@ -52,8 +52,8 @@ const ProductPresenter = ({
       <Grid className="product-info-container">
         <Grid className="product-info-price-container">
           <span>
-            {`${AddComma(sale_price)}`}
-            <del>{AddComma(original_price)}</del>
+            {`${addComma(sale_price)}`}
+            <del>{addComma(original_price)}</del>
           </span>
         </Grid>
         <span className="product-info-text"> {product_name} </span>

--- a/frontend/src/Components/ProductDetail/ProductDetailPresenter.js
+++ b/frontend/src/Components/ProductDetail/ProductDetailPresenter.js
@@ -2,6 +2,7 @@ import React from "react";
 
 import { Grid, Button } from "@material-ui/core";
 import { CU, SEVEN_ELEVEN, GS25, EMART24 } from "../Util/Constant";
+import AddComma from "../Util/AddComma";
 
 // id={id}
 // mart_name={mart_name}
@@ -44,14 +45,14 @@ const ProductDetailPresenter = ({
           <div className="item-info">
             <div className="item-price">
               <div className="item-original-price">
-                기존가: {item.original_price}원
+                기존가: {AddComma(item.original_price)}원
               </div>
-              <div className="item-sale-price">할인가: {item.sale_price}원</div>
+              <div className="item-sale-price">
+                할인가: {AddComma(item.sale_price)}원
+              </div>
             </div>
-            {sale_percent !== Infinity ? (
+            {sale_percent !== Infinity && (
               <div className="item-sale-percent">{sale_percent}% 할인!</div>
-            ) : (
-              ""
             )}
           </div>
         </Grid>

--- a/frontend/src/Components/ProductDetail/ProductDetailPresenter.js
+++ b/frontend/src/Components/ProductDetail/ProductDetailPresenter.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Grid, Button } from "@material-ui/core";
 import { CU, SEVEN_ELEVEN, GS25, EMART24 } from "../Util/Constant";
-import AddComma from "../Util/AddComma";
+import addComma from "../Util/AddComma";
 
 // id={id}
 // mart_name={mart_name}
@@ -45,10 +45,10 @@ const ProductDetailPresenter = ({
           <div className="item-info">
             <div className="item-price">
               <div className="item-original-price">
-                기존가: {AddComma(item.original_price)}원
+                기존가: {addComma(item.original_price)}원
               </div>
               <div className="item-sale-price">
-                할인가: {AddComma(item.sale_price)}원
+                할인가: {addComma(item.sale_price)}원
               </div>
             </div>
             {sale_percent !== Infinity && (

--- a/frontend/src/Components/ProductList/ProductListContainer.js
+++ b/frontend/src/Components/ProductList/ProductListContainer.js
@@ -46,7 +46,7 @@ const ProductListContainer = ({ martList, searchKeyword, sortOption }) => {
         setList((prev) => [...prev, ...data.content]);
         currentPage.current++;
 
-        if (currentPage.current >= lastPage) {
+        if (currentPage.current > lastPage) {
           setIsLoadFinish(true);
         }
         setLastPage(data.totalPages);

--- a/frontend/src/Components/Register/RegisterButton/FacebookRegisterButton.js
+++ b/frontend/src/Components/Register/RegisterButton/FacebookRegisterButton.js
@@ -27,7 +27,7 @@ const FacebookRegisterButton = ({ history }) => {
 
       const res = await dispatch(registerUser(body));
 
-      if (res.payload.status === 200) {
+      if (res.payload.status === 201) {
         history.push("/login");
       } else {
         alert("회원가입에 실패하였습니다.");

--- a/frontend/src/Components/Register/RegisterButton/GoogleRegisterButton.js
+++ b/frontend/src/Components/Register/RegisterButton/GoogleRegisterButton.js
@@ -52,7 +52,7 @@ const GoogleRegisterButton = ({ history }) => {
       };
 
       const res = await dispatch(registerUser(body, tokenId));
-      if (res.payload.status === 200) {
+      if (res.payload.status === 201) {
         history.push("/login");
       } else {
         alert("회원가입에 실패하였습니다.");

--- a/frontend/src/Components/Register/RegisterButton/KaKaoRegisterButton.js
+++ b/frontend/src/Components/Register/RegisterButton/KaKaoRegisterButton.js
@@ -26,7 +26,7 @@ const KaKaoRegisterButton = ({ history }) => {
 
       const res = await dispatch(registerUser(body, token));
 
-      if (res.payload.status === 200) {
+      if (res.payload.status === 201) {
         history.push("/login");
       } else {
         alert("회원가입에 실패하였습니다.");

--- a/frontend/src/Components/Util/AddComma.js
+++ b/frontend/src/Components/Util/AddComma.js
@@ -1,0 +1,6 @@
+const AddComma = (number) => {
+  if (!number) return "";
+  return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+};
+
+export default AddComma;

--- a/frontend/src/Components/Util/AddComma.js
+++ b/frontend/src/Components/Util/AddComma.js
@@ -1,6 +1,6 @@
-const AddComma = (number) => {
+const addComma = (number) => {
   if (!number) return "";
-  return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return number.toLocaleString();
 };
 
-export default AddComma;
+export default addComma;

--- a/frontend/src/Components/Util/Constant.js
+++ b/frontend/src/Components/Util/Constant.js
@@ -14,6 +14,8 @@ export const KAKAO = "kakao";
 export const GOOGLE = "google";
 export const FACEBOOK = "facebook";
 
-export const BEFORE_PURCHASE = 0;
-export const AFTER_PURCHASE = 1;
-export const TIMEOVER_PURCHASE = 2;
+export const PURCHASE_OPTION = Object.freeze({
+  BEFORE_PURCHASE: 0,
+  AFTER_PURCHASE: 1,
+  TIMEOVER_PURCHASE: 2,
+});

--- a/frontend/src/Components/Util/Constant.js
+++ b/frontend/src/Components/Util/Constant.js
@@ -13,3 +13,7 @@ export const EMART24 = "emart24";
 export const KAKAO = "kakao";
 export const GOOGLE = "google";
 export const FACEBOOK = "facebook";
+
+export const BEFORE_PURCHASE = 0;
+export const AFTER_PURCHASE = 1;
+export const TIMEOVER_PURCHASE = 2;

--- a/frontend/src/Components/Util/Request.js
+++ b/frontend/src/Components/Util/Request.js
@@ -10,8 +10,8 @@ const getHeader = (_tokenId) => {
   return {
     headers: {
       authorization: tokenId,
-      withCredentials: true,
     },
+    withCredentials: true,
   };
 };
 

--- a/frontend/src/Components/Util/useSetMyBagList.js
+++ b/frontend/src/Components/Util/useSetMyBagList.js
@@ -21,8 +21,8 @@ const useSetMyBagList = () => {
         }
         // 새로운 list반환
         return item.status === PURCHASE_OPTION.BEFORE_PURCHASE
-          ? [[item, ...wish], purchased]
-          : [wish, [item, ...purchased]];
+          ? [[...wish, item], purchased]
+          : [wish, [...purchased, item]];
       },
       [[], []]
     );

--- a/frontend/src/Components/Util/useSetMyBagList.js
+++ b/frontend/src/Components/Util/useSetMyBagList.js
@@ -1,0 +1,58 @@
+import { useState, useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { getMyBagList } from "../../Store/Actions/productAction";
+import { PURCHASE_OPTION } from "./Constant";
+
+const useSetMyBagList = () => {
+  const dispatch = useDispatch();
+
+  const [wishList, setWishList] = useState([]);
+  const [purchasedList, setPurchasedList] = useState([]);
+
+  const setNextList = (nextList, willUpdateStatusProductId) => {
+    const [nextWishList, nextPurchasedList] = nextList.reduce(
+      ([wish, purchased], item) => {
+        // 상태를 바꿔야 하는 품목만 상태 변경
+        if (item.productId === willUpdateStatusProductId) {
+          item.status =
+            item.status === PURCHASE_OPTION.BEFORE_PURCHASE
+              ? PURCHASE_OPTION.AFTER_PURCHASE
+              : PURCHASE_OPTION.BEFORE_PURCHASE;
+        }
+        // 새로운 list반환
+        return item.status === PURCHASE_OPTION.BEFORE_PURCHASE
+          ? [[item, ...wish], purchased]
+          : [wish, [item, ...purchased]];
+      },
+      [[], []]
+    );
+    setWishList(nextWishList);
+    setPurchasedList(nextPurchasedList);
+  };
+
+  useEffect(() => {
+    const getMyBagListFun = async () => {
+      const res = await dispatch(getMyBagList());
+      if (res.payload.status === 200) {
+        const itemNumberList = res.payload.data;
+        const nextMyBagList = itemNumberList.map((item) => {
+          return {
+            productId: item.product.productId,
+            productName: item.product.productName,
+            productImage: item.product.productImage,
+            originalPrice: item.product.originalPrice,
+            salePrice: item.product.salePrice,
+            productCnt: item.count,
+            status: item.status,
+          };
+        });
+        setNextList(nextMyBagList);
+      }
+    };
+    getMyBagListFun();
+  }, [dispatch]);
+
+  return [wishList, purchasedList, setNextList];
+};
+
+export default useSetMyBagList;

--- a/frontend/src/Pages/MyBagPage.js
+++ b/frontend/src/Pages/MyBagPage.js
@@ -1,70 +1,84 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 
 import AppBar from "@material-ui/core/AppBar";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
+import { Link } from "react-router-dom";
 
 import MyBag from "../Components/MyBag";
 import Layout from "../Components/Layout";
 import "../scss/MyBagPage.scss";
-import { Link } from "react-router-dom";
 import HelmetComponent from "../Components/HelmetComponent";
+import { PURCHASE_OPTION } from "../Components/Util/Constant";
+import useSetMyBagList from "../Components/Util/useSetMyBagList";
+
+const LogoLong = () => {
+  return (
+    <Link to="/main">
+      <div className="logo-long-text-container">
+        <img
+          className="logo-image"
+          src={`/img/logo_long_and_text_512.png`}
+          alt="logo"
+        />
+      </div>
+    </Link>
+  );
+};
+
+const SortBar = ({ filterOption, handleFilterOptionChange }) => {
+  return (
+    <div className="sort-bar-container">
+      <AppBar position="static" className="mybag-filter-bar">
+        <Tabs
+          value={filterOption}
+          onChange={handleFilterOptionChange}
+          aria-label="simple tabs example"
+        >
+          <Tab label="구매 예정"></Tab>
+          <Tab label="구매 내역"></Tab>
+          <Tab label=" " disabled></Tab>
+        </Tabs>
+        {filterOption === PURCHASE_OPTION.BEFORE_PURCHASE ? (
+          <div className="tab-price-container">
+            <div className="tab-description"> 얼마를 아낄까? </div>
+            <div className="tab-price"> 23,501원 </div>
+          </div>
+        ) : (
+          <div className="tab-price-container">
+            <div className="tab-description"> 얼마를 아꼈을까?</div>
+            <div className="tab-price"> 23,501원 </div>
+          </div>
+        )}
+      </AppBar>
+    </div>
+  );
+};
 
 const ProductListPage = () => {
-  const [filterOption, setFilterOption] = useState(0);
+  const [wishList, purchasedList, setNextList] = useSetMyBagList();
+  const [filterOption, setFilterOption] = useState(
+    PURCHASE_OPTION.BEFORE_PURCHASE
+  );
 
-  const LogoLong = () => {
-    return (
-      <Link to="/main">
-        <div className="logo-long-text-container">
-          <img
-            className="logo-image"
-            src={`/img/logo_long_and_text_512.png`}
-            alt="logo"
-          />
-        </div>
-      </Link>
-    );
-  };
-
-  const SortBar = () => {
-    const handleChange = (event, newOption) => {
-      setFilterOption(newOption);
-    };
-    return (
-      <div className="sort-bar-container">
-        <AppBar position="static" className="mybag-filter-bar">
-          <Tabs
-            value={filterOption}
-            onChange={handleChange}
-            aria-label="simple tabs example"
-          >
-            <Tab label="구매 예정"></Tab>
-            <Tab label="구매 내역"></Tab>
-            <Tab label=" " disabled></Tab>
-          </Tabs>
-          {filterOption === 0 ? (
-            <div className="tab-price-container">
-              <div className="tab-description"> 얼마를 아낄까? </div>
-              <div className="tab-price"> 23,501원 </div>
-            </div>
-          ) : (
-            <div className="tab-price-container">
-              <div className="tab-description"> 얼마를 아꼈을까?</div>
-              <div className="tab-price"> 23,501원 </div>
-            </div>
-          )}
-        </AppBar>
-      </div>
-    );
-  };
+  const handleFilterOptionChange = useCallback((_, newOption) => {
+    setFilterOption(newOption);
+  }, []);
 
   return (
     <Layout>
       <HelmetComponent subTitle={"장바구니"} />
       <LogoLong />
-      <SortBar />
-      <MyBag filterOption={filterOption} />
+      <SortBar
+        filterOption={filterOption}
+        handleFilterOptionChange={handleFilterOptionChange}
+      />
+      <MyBag
+        filterOption={filterOption}
+        wishList={wishList}
+        purchasedList={purchasedList}
+        setNextList={setNextList}
+      />
     </Layout>
   );
 };

--- a/frontend/src/Store/Actions/productAction.js
+++ b/frontend/src/Store/Actions/productAction.js
@@ -64,7 +64,8 @@ export const getMyBagList = async () => {
 };
 
 export const changeMyBagCnt = async (prodcutId, body) => {
-  const res = await request.post(`/api/mybag/${prodcutId}`, body);
+  const res = await request.post(`/api/mybag/changecnt/${prodcutId}`, body);
+
   return {
     type: CHANGE_MY_BAG_PRODUCT_CNT,
     payload: res,

--- a/frontend/src/Store/Actions/userAction.js
+++ b/frontend/src/Store/Actions/userAction.js
@@ -60,7 +60,7 @@ export const getUserInfo = async () => {
 };
 
 export const getUserProfit = async () => {
-  const res = await request.post(`/api/mybag/prices`, {});
+  const res = await request.get(`/api/mybag/prices`);
 
   return {
     type: GET_USER_PROFIT,


### PR DESCRIPTION
## 작업 내용

- [인피니티스크롤 초기 이슈] `=`때문에 검색 후 인피니티가 안되었던 점을 참고로, `=`제거했습니다.
- [axios withCredentials 위치 변경] headers내부에 있어서 가끔 인식이 이상하게 되는 것 같던데, 앞으로 뻇습니다!
- [status code match] 기존에 status 성공이 201이었지만 200으로 설정했던 코드가 있어 바꾸었습니다.
- [API 매칭] 몇몇 오류가 있던 API이슈가 있어서 해결했습니다.
- [장바구니 로직 분리] 현재 구매예정, 구매하고싶은 리스트가 묶여있어서 같은 상품을 보이던 것을 수정했습니다. 기존의 `BagProduct` -> 
`WishBagProduct`, `PurhcasedBagProduct`로 바꾸었습니다.
- [AddComma Util 작성] 기존 숫자를 보여지던 부분을 3자리로 나누어서 comma를 찍어주는 유틸 함수를 제작했습니다.

## 전달 사항
- 현재, 상품 삭제 및 구매했을 때 장바구니 창에서 바로 안없어지는 비동기 이슈가 있습니다..! 해결해보려고 했지만 작업 시작 중이신 것 같아서 미리 PR날립니다.
- `BuyModal` 상품 매칭(가격 정보 표시 부분만 미구현)도 아직 미구현입니다!
- `ProductDetail` 에서 렌더링 이슈가 있어보입니다. 아직 제대로 확인은 못했습니다.
- 기존 `localhost`에서 `local.modimoa.kro.kr`로 테스트를 진행할 때, 해당 API주소로 googleLogin이 설정이 안되어서 카카오 로그인만 가능합니다. 카카오 로그인 또한 쿠키 설정 이슈가 있어서 작업하실 때에는 백엔드분한테 개인적으로 로그인 후 `accessToken`을 받아서 하면 작동이 잘 됩니다.

## 궁금한 점
 
## 스크린샷 (선택)
