### PR TITLE
맞지 않는 레이아웃 수정, 뒤로 가기 버튼 리팩토링

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,12 @@ import { BrowserRouter } from "react-router-dom";
 import Router from "./Routes/Router";
 
 const App = () => {
+  const vh = window.innerHeight * 0.01;
+  document.documentElement.style.setProperty("--vh", `${vh}px`);
+  window.addEventListener("resize", () => {
+    const vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty("--vh", `${vh}px`);
+  });
   return (
     <BrowserRouter>
       <Router />

--- a/frontend/src/Components/Layout/LayoutContainer.js
+++ b/frontend/src/Components/Layout/LayoutContainer.js
@@ -1,24 +1,23 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { useParams } from "react-router-dom";
 import LayoutPresenter from "./LayoutPresenter";
 
 const LayoutContainer = ({ children }) => {
   const pathname = window.location.pathname;
-  const params = useParams();
   const [showSideMenu, setShowSideMenu] = useState(false);
   const [isNotRequiredBackBtn, setIsNotRequiredBackBtn] = useState(true);
 
   const isNowPageRequiredBackBtn = useCallback(() => {
     const noBackBtnPage = ["list", "main"];
-    const isPageInlist = noBackBtnPage.includes(pathname.split("/")[1]); // 0: ""
+    const params = pathname.split("/"); // 0: "", 1: "list", 2: ":id"
+    const isPageInlist = noBackBtnPage.includes(params[1]);
     if (!isPageInlist) {
       return false;
     }
-    if (pathname.includes("list") && params.id) {
+    if (pathname.includes("list") && params[2]) {
       return false;
     }
     return true;
-  }, [pathname, params]);
+  }, [pathname]);
 
   useEffect(() => {
     setIsNotRequiredBackBtn(isNowPageRequiredBackBtn());

--- a/frontend/src/Components/Layout/LayoutContainer.js
+++ b/frontend/src/Components/Layout/LayoutContainer.js
@@ -1,28 +1,29 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
+import { useParams } from "react-router-dom";
 import LayoutPresenter from "./LayoutPresenter";
 
 const LayoutContainer = ({ children }) => {
+  const pathname = window.location.pathname;
+  const params = useParams();
   const [showSideMenu, setShowSideMenu] = useState(false);
-  const [isNotRequiredBackBtn, setIsNotRequiredBackBtn] = useState(false);
+  const [isNotRequiredBackBtn, setIsNotRequiredBackBtn] = useState(true);
 
-  const isNowPage = (page) => {
-    const isNow = window.location.pathname.indexOf(page);
-    if (isNow !== -1) {
-      return true;
+  const isNowPageRequiredBackBtn = useCallback(() => {
+    const noBackBtnPage = ["list", "main"];
+    const isPageInlist = noBackBtnPage.includes(pathname.split("/")[1]); // 0: ""
+    if (!isPageInlist) {
+      return false;
     }
-
-    return false;
-  };
+    if (pathname.includes("list") && params.id) {
+      return false;
+    }
+    return true;
+  }, [pathname, params]);
 
   useEffect(() => {
-    const noBackBtnPage = ["/list", "/main", "list/", "about", "/"];
-    noBackBtnPage.forEach((page, idx) => {
-      if (isNowPage(page) && idx !== 2) setIsNotRequiredBackBtn(true);
-      else if (isNowPage(page) && idx === 2) setIsNotRequiredBackBtn(false);
-    });
-
+    setIsNotRequiredBackBtn(isNowPageRequiredBackBtn());
     return () => setIsNotRequiredBackBtn(false);
-  }, [children, isNotRequiredBackBtn]);
+  }, [isNowPageRequiredBackBtn]);
 
   return (
     <LayoutPresenter

--- a/frontend/src/Components/Layout/LayoutPresenter.js
+++ b/frontend/src/Components/Layout/LayoutPresenter.js
@@ -12,12 +12,6 @@ const LayoutPresenter = ({
   setShowSideMenu,
   isNotRequiredBackBtn,
 }) => {
-  const vh = window.innerHeight * 0.01;
-  document.documentElement.style.setProperty("--vh", `${vh}px`);
-  window.addEventListener("resize", () => {
-    const vh = window.innerHeight * 0.01;
-    document.documentElement.style.setProperty("--vh", `${vh}px`);
-  });
   return (
     <div className="layout-container">
       <SideMenuBtn

--- a/frontend/src/Components/Layout/SideMenuBtn/SideMenuBtnContainer.js
+++ b/frontend/src/Components/Layout/SideMenuBtn/SideMenuBtnContainer.js
@@ -2,26 +2,12 @@ import React, { useLayoutEffect } from "react";
 import { useDispatch } from "react-redux";
 
 import { openedSideMenu } from "../../../Store/Actions/sideMenuAction";
+import detectMobile from "../../Util/DetectMobile";
 
 import SideMenuBtnPresenter from "./SideMenuBtnPresenter";
 
 const SideMenuBtnContainer = ({ showSideMenu, setShowSideMenu }) => {
   const dispatch = useDispatch();
-  const detectMobile = () => {
-    const toMatch = [
-      /Android/i,
-      /webOS/i,
-      /iPhone/i,
-      /iPod/i,
-      /BlackBerry/i,
-      /Windows Phone/i,
-    ];
-
-    return toMatch.some((toMatchItem) => {
-      return navigator.userAgent.match(toMatchItem);
-    });
-  };
-
   const handleSideMenuBtnClick = (event) => {
     event.preventDefault();
     setShowSideMenu(!showSideMenu);

--- a/frontend/src/Components/MartList/MartListBtn/MartListBtnContainer.js
+++ b/frontend/src/Components/MartList/MartListBtn/MartListBtnContainer.js
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 
 import { selectMart } from "../../../Store/Actions/martAction";
+import detectMobile from "../../Util/DetectMobile";
 
 import MartListBtnPresenter from "./MartListBtnPresenter";
 
@@ -12,21 +13,6 @@ const MartListBtnContainer = ({
 }) => {
   const dispatch = useDispatch();
   const [isAllDeactivation, setIsAllDeActivation] = useState(false);
-
-  const detectMobile = () => {
-    const toMatch = [
-      /Android/i,
-      /webOS/i,
-      /iPhone/i,
-      /iPod/i,
-      /BlackBerry/i,
-      /Windows Phone/i,
-    ];
-
-    return toMatch.some((toMatchItem) => {
-      return navigator.userAgent.match(toMatchItem);
-    });
-  };
 
   const handleMartListBtnClick = useCallback(
     (event) => {

--- a/frontend/src/Components/Util/DetectMobile.js
+++ b/frontend/src/Components/Util/DetectMobile.js
@@ -1,0 +1,16 @@
+const detectMobile = () => {
+  const toMatch = [
+    /Android/i,
+    /webOS/i,
+    /iPhone/i,
+    /iPod/i,
+    /BlackBerry/i,
+    /Windows Phone/i,
+  ];
+
+  return toMatch.some((toMatchItem) => {
+    return navigator.userAgent.match(toMatchItem);
+  });
+};
+
+export default detectMobile;

--- a/frontend/src/Routes/Router.js
+++ b/frontend/src/Routes/Router.js
@@ -13,22 +13,9 @@ import {
   About,
 } from "../Pages";
 import Auth from "../Components/Util/Auth";
+import detectMobile from "../Components/Util/DetectMobile";
 
 const Router = () => {
-  const detectMobile = () => {
-    const toMatch = [
-      /Android/i,
-      /webOS/i,
-      /iPhone/i,
-      /iPod/i,
-      /BlackBerry/i,
-      /Windows Phone/i,
-    ];
-
-    return toMatch.some((toMatchItem) => {
-      return navigator.userAgent.match(toMatchItem);
-    });
-  };
   return (
     <Switch>
       {detectMobile() && <Route exact path="/" component={Auth(Intro, null)} />}

--- a/frontend/src/scss/Layout.scss
+++ b/frontend/src/scss/Layout.scss
@@ -51,7 +51,7 @@ body {
   background-color: #f0f1f3;
   border-radius: 5px;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-  z-index: 5;
+  z-index: 3;
   cursor: pointer;
 
   img {

--- a/frontend/src/scss/Layout.scss
+++ b/frontend/src/scss/Layout.scss
@@ -60,4 +60,8 @@ body {
     transform: translateY(50%);
     max-width: 50%;
   }
+
+  @include desktop {
+    display: none;
+  }
 }

--- a/frontend/src/scss/components/_intro.scss
+++ b/frontend/src/scss/components/_intro.scss
@@ -4,7 +4,7 @@
   align-items: center;
   justify-content: space-evenly;
   width: 100vw;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   background-color: $beer;
   .logo-container,
   .slogan-container,

--- a/frontend/src/scss/components/_sideMenu.scss
+++ b/frontend/src/scss/components/_sideMenu.scss
@@ -23,7 +23,7 @@
 
   @include mobile {
     position: absolute;
-    z-index: 3;
+    z-index: 5;
     background-color: $black;
     width: calc(100% - 1rem); // 1rem: padding
     height: 100%;

--- a/frontend/src/scss/components/_sideMenuBtn.scss
+++ b/frontend/src/scss/components/_sideMenuBtn.scss
@@ -13,7 +13,7 @@
   line-height: 50px;
   font-size: 2rem;
   text-align: center;
-  z-index: 5;
+  z-index: 7;
 
   @include desktop {
     display: none;


### PR DESCRIPTION
## 작업 내용

- [x] 인트로 페이지 모바일 브라우저 하단 바 고려하게
- [x] 뒤로 가기 버튼 로직 리팩토링
- [x] DetectMobile.js 분리
- [x] 사이드 메뉴 / 사이드 메뉴 닫기 버튼 / 뒤로 가기 버튼 z-index 수정
- [x] Desktop에서는 뒤로 가기 버튼 아예 안보이게

## 전달 사항

뒤로 가기 버튼을 보이게 하느냐를 판단할 때 `useEffect`에 `forEach` + `indexOf`로 판단하는 것을 `includes`로 통일했고, `useCallback`을 사용했습니다. 근데 `useCallback`을 잘 사용한 건지는 모르겠네요,,

상품 리스트 페이지 `/list` 에서는 우측 상단에 마트 선택 버튼이 있어야 해서 뒤로 가기 버튼이 있으면 안되고,
~~상품 상세 페이지 `/list/:id`에서는 뒤로 가기 버튼이 있어야 할 것 같아 이를 `useParams`로 id가 있는 지를 판단하게 했습니다.~~
`useParams`없이 그냥 pathname.split("/")[2]가 있는지 확인해도 되겠네요 수정했습니다!

## 궁금한 점

## 스크린샷 (선택)

<div>
<img width="33%" src="https://user-images.githubusercontent.com/42960217/150526693-06752656-9951-4c66-b909-702d574760f8.png" />
<img width="33%" src="https://user-images.githubusercontent.com/42960217/150526673-12fb826c-a0b6-409e-996d-c335ef29a98b.png" />
<img width="33%" src="https://user-images.githubusercontent.com/42960217/150526710-c6c1864b-1158-4c61-a4f6-96c359dc6c2d.png" />
</div>