### PR TITLE
상품 목록 페이지 Desktop ver. 1차

### DIFF
--- a/frontend/src/Components/About/AboutPresenter.js
+++ b/frontend/src/Components/About/AboutPresenter.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-import NavigateBeforeIcon from "@material-ui/icons/NavigateBefore";
-import NavigateNextIcon from "@material-ui/icons/NavigateNext";
+import NavigateBeforeIcon from "@material-ui/icons/NavigateBeforeRounded";
+import NavigateNextIcon from "@material-ui/icons/NavigateNextRounded";
 
 import AboutWhoPresenter from "./AboutWhoPresenter";
 import AboutWhatPresenter from "./AboutWhatPresenter";

--- a/frontend/src/Components/Layout/LayoutContainer.js
+++ b/frontend/src/Components/Layout/LayoutContainer.js
@@ -1,34 +1,48 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useLocation } from "react-router-dom";
+import detectMobile from "../Util/DetectMobile";
 import LayoutPresenter from "./LayoutPresenter";
 
 const LayoutContainer = ({ children }) => {
-  const pathname = window.location.pathname;
+  const pathname = useLocation().pathname;
   const [showSideMenu, setShowSideMenu] = useState(false);
-  const [isNotRequiredBackBtn, setIsNotRequiredBackBtn] = useState(true);
+  const [isRequiredBackBtn, setIsRequiredBackBtn] = useState(true);
+  const [isRequiredSideMenuBtn, setIsRequiredSideMenuBtn] = useState(true);
 
   const isNowPageRequiredBackBtn = useCallback(() => {
     const noBackBtnPage = ["list", "main"];
     const params = pathname.split("/"); // 0: "", 1: "list", 2: ":id"
     const isPageInlist = noBackBtnPage.includes(params[1]);
     if (!isPageInlist) {
-      return false;
+      return true;
     }
     if (pathname.includes("list") && params[2]) {
-      return false;
+      return true;
     }
-    return true;
+    return false;
   }, [pathname]);
 
+  const isNowPageRequiredSideMenuBtn = useCallback(
+    () =>
+      detectMobile() ||
+      (pathname !== "/" && pathname !== "/main" && !pathname.includes("about")),
+    [pathname]
+  );
   useEffect(() => {
-    setIsNotRequiredBackBtn(isNowPageRequiredBackBtn());
-    return () => setIsNotRequiredBackBtn(false);
-  }, [isNowPageRequiredBackBtn]);
+    setIsRequiredBackBtn(isNowPageRequiredBackBtn());
+    setIsRequiredSideMenuBtn(isNowPageRequiredSideMenuBtn());
+    return () => {
+      setIsRequiredBackBtn(false);
+      setIsRequiredSideMenuBtn(false);
+    };
+  }, [isNowPageRequiredBackBtn, isNowPageRequiredSideMenuBtn]);
 
   return (
     <LayoutPresenter
       showSideMenu={showSideMenu}
       setShowSideMenu={setShowSideMenu}
-      isNotRequiredBackBtn={isNotRequiredBackBtn}
+      isRequiredBackBtn={isRequiredBackBtn}
+      isRequiredSideMenuBtn={isRequiredSideMenuBtn}
     >
       {children}
     </LayoutPresenter>

--- a/frontend/src/Components/Layout/LayoutPresenter.js
+++ b/frontend/src/Components/Layout/LayoutPresenter.js
@@ -10,16 +10,19 @@ const LayoutPresenter = ({
   children,
   showSideMenu,
   setShowSideMenu,
-  isNotRequiredBackBtn,
+  isRequiredBackBtn,
+  isRequiredSideMenuBtn,
 }) => {
   return (
     <div className="layout-container">
-      <SideMenuBtn
-        showSideMenu={showSideMenu}
-        setShowSideMenu={setShowSideMenu}
-      />
-      {showSideMenu ? <SideMenu setShowSideMenu={setShowSideMenu} /> : null}
-      {isNotRequiredBackBtn ? null : <BackButton />}
+      {isRequiredSideMenuBtn && (
+        <SideMenuBtn
+          showSideMenu={showSideMenu}
+          setShowSideMenu={setShowSideMenu}
+        />
+      )}
+      {showSideMenu && <SideMenu setShowSideMenu={setShowSideMenu} />}
+      {isRequiredBackBtn && <BackButton />}
       <Grid id="wrap"> {children} </Grid>
     </div>
   );

--- a/frontend/src/Components/Layout/SideMenuBtn/SideMenuBtnContainer.js
+++ b/frontend/src/Components/Layout/SideMenuBtn/SideMenuBtnContainer.js
@@ -19,11 +19,11 @@ const SideMenuBtnContainer = ({ showSideMenu, setShowSideMenu }) => {
    */
   useLayoutEffect(() => {
     const isMobile = detectMobile();
-
     if (!isMobile) {
       setShowSideMenu(true);
+      dispatch(openedSideMenu(true));
     }
-  }, [setShowSideMenu]);
+  }, [dispatch, setShowSideMenu]);
 
   return (
     <SideMenuBtnPresenter

--- a/frontend/src/Components/Layout/SideMenuBtn/SideMenuBtnPresenter.js
+++ b/frontend/src/Components/Layout/SideMenuBtn/SideMenuBtnPresenter.js
@@ -1,9 +1,36 @@
 import React from "react";
+import ClearIcon from "@material-ui/icons/Clear";
+import MenuOpenIcon from "@material-ui/icons/MenuOpen";
+import NavigateBeforeIcon from "@material-ui/icons/NavigateBeforeRounded";
+import NavigateNextIcon from "@material-ui/icons/NavigateNextRounded";
+import detectMobile from "../../Util/DetectMobile";
+
+const BtnIcon = ({ showSideMenu }) => {
+  const isMobile = detectMobile();
+  if (isMobile) {
+    if (showSideMenu) {
+      return <ClearIcon />;
+    } else {
+      return <MenuOpenIcon />;
+    }
+  } else {
+    if (showSideMenu) {
+      return <NavigateBeforeIcon />;
+    } else {
+      return <NavigateNextIcon />;
+    }
+  }
+};
 
 const SideMenuBtnPresenter = ({ handleSideMenuBtnClick, showSideMenu }) => {
   return (
-    <div className="side-modal-btn" onClick={handleSideMenuBtnClick}>
-      {!showSideMenu ? "≡" : "X"}
+    <div
+      className={`side-modal-btn ${
+        showSideMenu ? "side-modal-btn-open" : "side-modal-btn-close"
+      }`}
+      onClick={handleSideMenuBtnClick}
+    >
+      <BtnIcon showSideMenu={showSideMenu} />
     </div>
   );
 };

--- a/frontend/src/Components/MartList/MartListBtn/MartListBtnContainer.js
+++ b/frontend/src/Components/MartList/MartListBtn/MartListBtnContainer.js
@@ -10,6 +10,7 @@ const MartListBtnContainer = ({
   showMartList,
   setShowMartList,
   tempMartList,
+  openedSideMenu,
 }) => {
   const dispatch = useDispatch();
   const [isAllDeactivation, setIsAllDeActivation] = useState(false);
@@ -54,6 +55,7 @@ const MartListBtnContainer = ({
     <MartListBtnPresenter
       handleMartListBtnClick={handleMartListBtnClick}
       showMartList={showMartList}
+      openedSideMenu={openedSideMenu}
     />
   );
 };

--- a/frontend/src/Components/MartList/MartListBtn/MartListBtnPresenter.js
+++ b/frontend/src/Components/MartList/MartListBtn/MartListBtnPresenter.js
@@ -1,10 +1,10 @@
 import React from "react";
-import { useSelector } from "react-redux";
 
-const MartListBtnPresenter = ({ handleMartListBtnClick, showMartList }) => {
-  const openedSideMenu = useSelector(
-    (state) => state.sideMenuReducer.openedSideMenu
-  );
+const MartListBtnPresenter = ({
+  handleMartListBtnClick,
+  showMartList,
+  openedSideMenu,
+}) => {
   const className = openedSideMenu
     ? `martlist-modal-btn martlist-modal-btn-hide`
     : `martlist-modal-btn`;

--- a/frontend/src/Components/MartList/MartListContainer.js
+++ b/frontend/src/Components/MartList/MartListContainer.js
@@ -1,9 +1,16 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import detectMobile from "../Util/DetectMobile";
 import MartListPresenter from "./MartListPresenter";
 
 const MartListContainer = ({ martList }) => {
   const [showMartList, setShowMartList] = useState(false);
   const [tempMartList, setTempMartList] = useState(martList);
+
+  useEffect(() => {
+    if (!detectMobile()) {
+      setShowMartList(true);
+    }
+  }, []);
 
   return (
     <MartListPresenter

--- a/frontend/src/Components/MartList/MartListContainer.js
+++ b/frontend/src/Components/MartList/MartListContainer.js
@@ -1,10 +1,14 @@
 import React, { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
 import detectMobile from "../Util/DetectMobile";
 import MartListPresenter from "./MartListPresenter";
 
 const MartListContainer = ({ martList }) => {
   const [showMartList, setShowMartList] = useState(false);
   const [tempMartList, setTempMartList] = useState(martList);
+  const openedSideMenu = useSelector(
+    (state) => state.sideMenuReducer.openedSideMenu
+  );
 
   useEffect(() => {
     if (!detectMobile()) {
@@ -19,6 +23,7 @@ const MartListContainer = ({ martList }) => {
       martList={martList}
       tempMartList={tempMartList}
       setTempMartList={setTempMartList}
+      openedSideMenu={openedSideMenu}
     />
   );
 };

--- a/frontend/src/Components/MartList/MartListPresenter.js
+++ b/frontend/src/Components/MartList/MartListPresenter.js
@@ -65,9 +65,13 @@ const LogoIcon = ({ name, martList, setTempMartList }) => {
   );
 };
 
-const MartListModal = ({ martList, setTempMartList }) => {
+const MartListModal = ({ martList, setTempMartList, openedSideMenu }) => {
   return (
-    <div className="martlist-container">
+    <div
+      className={`martlist-container ${
+        openedSideMenu ? "martlist-container-right" : ""
+      }`}
+    >
       <span> 보고 싶은 편의점의 제품만 골라서 보실 수 있습니다. </span>
       <div className="martlist-mart-container">
         <LogoIcon
@@ -100,6 +104,7 @@ const MartListPresenter = ({
   setShowMartList,
   tempMartList,
   setTempMartList,
+  openedSideMenu,
 }) => {
   return (
     <>
@@ -108,11 +113,13 @@ const MartListPresenter = ({
         showMartList={showMartList}
         setShowMartList={setShowMartList}
         setTempMartList={setTempMartList}
+        openedSideMenu={openedSideMenu}
       />
       {showMartList ? (
         <MartListModal
           martList={tempMartList}
           setTempMartList={setTempMartList}
+          openedSideMenu={openedSideMenu}
         />
       ) : null}
     </>

--- a/frontend/src/Store/Reducers/sideMenuReducer.js
+++ b/frontend/src/Store/Reducers/sideMenuReducer.js
@@ -1,6 +1,11 @@
+import detectMobile from "../../Components/Util/DetectMobile";
 import { CLOSED_SIDE_MENU, OPENED_SIDE_MENU } from "../Actions/type";
 
-const sideMenuReducer = (state = {}, action) => {
+const initialState = {
+  openedSideMenu: !detectMobile(),
+};
+
+const sideMenuReducer = (state = initialState, action) => {
   switch (action.type) {
     case OPENED_SIDE_MENU:
       return { ...state, openedSideMenu: action.payload };

--- a/frontend/src/scss/ProductList.scss
+++ b/frontend/src/scss/ProductList.scss
@@ -11,7 +11,13 @@
 
 .product-list-container {
     display: flex;
-    overflow: scroll;
+    overflow-y: scroll;
     width: 100%;
     flex-direction: column;
+    @include desktop {
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 1rem;
+        justify-content: center;
+    }
 }

--- a/frontend/src/scss/ProductList.scss
+++ b/frontend/src/scss/ProductList.scss
@@ -1,7 +1,7 @@
 // Login page scss
 
 // default scss
-@import './base/base';
+@import "./base/base";
 @import "./base/variable";
 @import "./base/mixin";
 
@@ -10,14 +10,14 @@
 @import "./components/martLabel";
 
 .product-list-container {
-    display: flex;
-    overflow-y: scroll;
-    width: 100%;
-    flex-direction: column;
-    @include desktop {
-        flex-direction: row;
-        flex-wrap: wrap;
-        gap: 1rem;
-        justify-content: center;
-    }
+  display: flex;
+  overflow-y: scroll;
+  width: 100%;
+  flex-direction: column;
+  @include desktop {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    justify-items: center;
+    gap: 1rem;
+  }
 }

--- a/frontend/src/scss/components/_martList.scss
+++ b/frontend/src/scss/components/_martList.scss
@@ -45,14 +45,26 @@
       color: $white;
     }
   }
+  @include desktop {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    width: calc(100px - 2rem); // img: 70px
+    height: calc(100% - 2rem - 2rem);
+    padding: 1rem;
+    z-index: 7;
+    background-color: rgba(0, 0, 0, 0.7);
+    align-items: center;
+    border-radius: 10px;
+    & > span {
+      display: none;
+    }
+  }
 }
 
 .martlist-mart-container {
-  display: flex;
-  width: 100%;
-  justify-content: space-evenly;
-  position: absolute;
-  bottom: 10%;
   .martlist-mart-icon {
     img {
       border: 2px solid $black;
@@ -64,5 +76,16 @@
       border-color: rgba(0, 0, 0, 0);
       opacity: 0.5;
     }
+  }
+  @include mobile {
+    display: flex;
+    width: 100%;
+    justify-content: space-evenly;
+    position: absolute;
+    bottom: 10%;
+  }
+  @include desktop {
+    display: flex;
+    flex-direction: column;
   }
 }

--- a/frontend/src/scss/components/_martList.scss
+++ b/frontend/src/scss/components/_martList.scss
@@ -35,7 +35,7 @@
     position: absolute;
     top: 0;
     z-index: 7;
-    background-color: rgba(0,0,0,0.8);
+    background-color: rgba(0, 0, 0, 0.8);
     width: 100%;
     height: 100%;
     align-items: center;
@@ -61,6 +61,13 @@
     & > span {
       display: none;
     }
+    transition: left 0.5s ease-out;
+  }
+}
+
+.martlist-container-right {
+  @include desktop {
+    left: calc(20vw - 100px);
   }
 }
 

--- a/frontend/src/scss/components/_product.scss
+++ b/frontend/src/scss/components/_product.scss
@@ -2,34 +2,57 @@
   display: flex;
   flex-direction: row;
   height: 5rem;
-  @include desktop {
-    height: 10vh;
-  }
   border-bottom: 2px solid $line;
   a {
     text-decoration: none;
   }
+  @include desktop {
+    flex-direction: column;
+    width: 12rem;
+    height: 18rem;
+    border: 2px solid $line;
+  }
 }
 .product-image-container {
-  display: flex;
-  width: 20%;
-  height: 100%;
-  overflow: hidden;
-  img {
+  @include mobile {
+    display: flex;
+    width: 20%;
+    height: 100%;
+    overflow: hidden;
+    img {
+      width: 100%;
+      height: 5rem;
+    }
+  }
+  @include desktop {
     width: 100%;
-    height: 5rem;
+    img {
+      width: 100%;
+      height: 100%;
+    }
+    border-bottom: 2px solid $line;
   }
 }
 .product-info-container {
-  display: flex;
-  justify-content: space-evenly;
-  width: 60%;
-  flex-direction: column;
-  padding-left: 0.5rem;
-  .product-info-text {
-    height: 1rem;
-    overflow: hidden;
-    line-height: 1;
+  @include mobile {
+    display: flex;
+    justify-content: space-evenly;
+    width: 60%;
+    flex-direction: column;
+    padding-left: 0.5rem;
+    .product-info-text {
+      height: 1rem;
+      overflow: hidden;
+      line-height: 1;
+    }
+  }
+  @include desktop {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 0.4rem;
   }
 }
 .product-info-price-container {
@@ -39,6 +62,9 @@
     @include font-default(400, 1rem);
     del {
       @include font-default(400, 0.8rem);
+      @include desktop {
+        margin-left: 0.2rem;
+      }
     }
   }
 }
@@ -47,6 +73,9 @@
   width: 20%;
   .MuiButton-label {
     font-size: 0.8rem;
+  }
+  @include desktop {
+    display: none;
   }
 }
 .product-search-result-container {

--- a/frontend/src/scss/components/_sideMenu.scss
+++ b/frontend/src/scss/components/_sideMenu.scss
@@ -1,10 +1,9 @@
 .sidemenu-container {
   display: flex;
+  height: 100%;
   flex-direction: column;
-  flex-grow: 1;
   padding-left: 1rem;
   box-shadow: 5px 0px 4px rgba(0, 0, 0, 0.25);
-  min-width: 300px;
   a,
   div {
     display: flex;
@@ -42,6 +41,10 @@
     .sidemenu-foot {
       padding-left: 0rem;
     }
+  }
+
+  @include desktop {
+    min-width: 20vw;
   }
 
   .logo {

--- a/frontend/src/scss/components/_sideMenuBtn.scss
+++ b/frontend/src/scss/components/_sideMenuBtn.scss
@@ -21,16 +21,27 @@
     top: 50%;
     left: calc(1rem + 100px + 1rem + 1rem);
     transform: translate(-50%, -50%);
-    width: 50px;
-    height: 50px;
-    background-color: $background;
+    width: 4.5rem;
+    height: 4.5rem;
+    background-color: none;
     border-radius: 5px;
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 
     line-height: 50px;
     font-size: 2rem;
     text-align: center;
     z-index: 7;
     cursor: pointer;
+    transition: left 0.5s ease-out;
+
+    svg.MuiSvgIcon-root {
+      width: 100%;
+      height: 100%;
+    }
+  }
+}
+
+.side-modal-btn-open {
+  @include desktop {
+    left: calc(1rem + 1rem + 20vw);
   }
 }

--- a/frontend/src/scss/components/_sideMenuBtn.scss
+++ b/frontend/src/scss/components/_sideMenuBtn.scss
@@ -1,21 +1,36 @@
 .side-modal-btn {
-  position: fixed;
-  left: 20px;
-  top: 20px;
-  width: 50px;
-  height: 50px;
-  background-color: $background;
-  border-radius: 5px;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-  cursor: pointer;
+  @include mobile {
+    position: fixed;
+    left: 20px;
+    top: 20px;
+    width: 50px;
+    height: 50px;
+    background-color: $background;
+    border-radius: 5px;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 
-  /* temp, if icon have, delete this */
-  line-height: 50px;
-  font-size: 2rem;
-  text-align: center;
-  z-index: 7;
+    /* temp, if icon have, delete this */
+    line-height: 50px;
+    font-size: 2rem;
+    text-align: center;
+    z-index: 7;
+  }
 
   @include desktop {
-    display: none;
+    position: fixed;
+    top: 50%;
+    left: calc(1rem + 100px + 1rem + 1rem);
+    transform: translate(-50%, -50%);
+    width: 50px;
+    height: 50px;
+    background-color: $background;
+    border-radius: 5px;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+
+    line-height: 50px;
+    font-size: 2rem;
+    text-align: center;
+    z-index: 7;
+    cursor: pointer;
   }
 }


### PR DESCRIPTION
## 작업 내용

- [x] 상품 목록 그리드
- [x] 사이드 메뉴
- [x] 마트 목록

## 전달 사항

- **내 코드가 레거시다!** 라는 마음가짐으로 짜고 있습니다..

(앞으로)
- 상품 목록의 경우 상품을 클릭했을 시 상세 페이지로 이동하게 해야 함
- 이름순, 가격순도 따로 스타일링
- 검색창 스타일링
- 마트 리스트가 보이기는 하는데 아직 기능하지는 않고 있는 중

## 궁금한 점

피그마 기준 데스크탑에서는 상품 이름 / 가격 / 마트 이름 이런 순서로 각 상품을 표시하는데,
모바일에서는 가격부터 표시하고 있음! 순서를 서로 다르게 할 필요가 있을까요!?

## 스크린샷 (선택)
![image](https://user-images.githubusercontent.com/42960217/150723380-bae3c061-d940-4f12-9aae-ff0c106354c9.png)
![image](https://user-images.githubusercontent.com/42960217/150723365-f35f7941-1d8b-490c-aebc-57524d7e5bc5.png)
