### PR TITLE
[BE/Refactor] 장바구니 물품 id로 동작하도록 설정

### DIFF
--- a/backend/src/main/java/com/modimoa/backend/controller/UserController.java
+++ b/backend/src/main/java/com/modimoa/backend/controller/UserController.java
@@ -84,10 +84,16 @@ public class UserController {
 
 	// 로그아웃 기능
 	@PostMapping("/logout")
-	public ResponseEntity<String> logoutUserByToken(@RequestHeader HttpHeaders requestHeader) {
+	public ResponseEntity<String> logoutUserByToken(HttpServletResponse response, @RequestHeader HttpHeaders requestHeader) {
 
 		String logoutCookie = requestHeader.toSingleValueMap().get("authorization");
 		String userEmail = userService.logout(logoutCookie);
+
+		ResponseCookie cookie = ResponseCookie.from("accessToken", null)
+				.maxAge(0)
+				.build();
+
+		response.setHeader("Set-Cookie", cookie.toString());
 
 		return new ResponseEntity<>(userEmail+" 로그아웃 되었습니다.", HttpStatus.OK);
 	}

--- a/backend/src/main/java/com/modimoa/backend/controller/UserController.java
+++ b/backend/src/main/java/com/modimoa/backend/controller/UserController.java
@@ -84,16 +84,10 @@ public class UserController {
 
 	// 로그아웃 기능
 	@PostMapping("/logout")
-	public ResponseEntity<String> logoutUserByToken(HttpServletResponse response, @RequestHeader HttpHeaders requestHeader) {
+	public ResponseEntity<String> logoutUserByToken(@RequestHeader HttpHeaders requestHeader) {
 
 		String logoutCookie = requestHeader.toSingleValueMap().get("authorization");
 		String userEmail = userService.logout(logoutCookie);
-
-		ResponseCookie cookie = ResponseCookie.from("accessToken", null)
-				.maxAge(0)
-				.build();
-
-		response.setHeader("Set-Cookie", cookie.toString());
 
 		return new ResponseEntity<>(userEmail+" 로그아웃 되었습니다.", HttpStatus.OK);
 	}

--- a/backend/src/main/java/com/modimoa/backend/domain/MybagProduct.java
+++ b/backend/src/main/java/com/modimoa/backend/domain/MybagProduct.java
@@ -13,12 +13,14 @@ import java.util.Optional;
 public class MybagProduct {
 
 	private Optional<Product> product;
+	private long id;
 	private int count;
 	private int status;
 
 	@Builder
-	public MybagProduct(Optional<Product> product, int count, int status) {
+	public MybagProduct(Optional<Product> product, long id, int count, int status) {
 		this.product = product;
+		this.id = id;
 		this.count = count;
 		this.status = status;
 	}

--- a/backend/src/main/java/com/modimoa/backend/repository/MybagRepository.java
+++ b/backend/src/main/java/com/modimoa/backend/repository/MybagRepository.java
@@ -11,11 +11,13 @@ import java.util.Optional;
 @Repository
 public interface MybagRepository extends JpaRepository<Mybag, Long> {
 
-	Optional<Mybag> findByUserAndProductId(User user, Long productId);
-
-	void deleteByUserAndProductId(User user, Long productId);
-
 	List<Mybag> findByUser(User user);
 
 	void deleteByUser(User user);
+
+	void deleteByMybagId(Long mybagId);
+
+	Optional<Mybag> findByMybagId(Long mybagId);
+
+	Optional<Mybag> findByUserAndProductIdAndStatus(User user, Long productId, int i);
 }

--- a/backend/src/main/java/com/modimoa/backend/service/MybagService.java
+++ b/backend/src/main/java/com/modimoa/backend/service/MybagService.java
@@ -38,6 +38,7 @@ public class MybagService {
 		for (Mybag mybag : mybagList) {
 			MybagProduct mybagProduct = MybagProduct.builder()
 					.product(productRepository.findById(mybag.getProductId()))
+					.id(mybag.getMybagId())
 					.count(mybag.getCount())
 					.status(mybag.getStatus()).build();
 			productList.add(mybagProduct);
@@ -47,51 +48,53 @@ public class MybagService {
 
 	// 새 물품 추가
 	public String plusItemOrCreateCount(String accessToken, Long productId) {
-		Optional<User> user = userRepository.findByAccessToken(accessToken);
-		user.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
-		Mybag mybag = mybagRepository.findByUserAndProductId(user.get(), productId)
+		User user = userRepository.findByAccessToken(accessToken)
+			.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
+
+		Mybag mybag = mybagRepository.findByUserAndProductIdAndStatus(user, productId, 0)
 				.orElseGet(() -> mybagRepository
-						.save(new Mybag(user.get(), productId, 0, 0)));
+						.save(new Mybag(user, productId, 0, 0)));
+
 		mybag.updateCount(1);
 
-		return user.get().getUserEmail();
+		return user.getUserEmail();
 	}
 
-	// product id로 물품 삭제
-	public String deleteItem(String accessToken, Long productId) {
-		Optional<User> user = userRepository.findByAccessToken(accessToken);
-		user.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
-		mybagRepository.deleteByUserAndProductId(user.get(), productId);
+	// TODO: [front] mybag id로 물품 삭제
+	public String deleteItem(String accessToken, Long mybagId) {
+		User user = userRepository.findByAccessToken(accessToken)
+			.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
+		mybagRepository.deleteByMybagId(mybagId);
 
-		return user.get().getUserEmail();
+		return user.getUserEmail();
 	}
 
-	// 물품 개수 변경
-	public String changeItemCount(String accessToken, Long productId, int count) {
+	// TODO: [front] mybag id로 물품 개수 변경
+	public String changeItemCount(String accessToken, Long mybagId, int count) {
+		User user = userRepository.findByAccessToken(accessToken)
+			.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
+		Mybag mybag = mybagRepository.findByMybagId(mybagId)
+			.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
 
-		Optional<User> user = userRepository.findByAccessToken(accessToken);
-		user.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
-		Optional<Mybag> mybag = mybagRepository.findByUserAndProductId(user.get(), productId);
-		mybag.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
-		mybag.get().setCount(count);
-		if (mybag.get().getCount() == 0) mybagRepository.deleteByUserAndProductId(user.get(), productId);
+		mybag.setCount(count);
+		if (mybag.getCount() == 0) mybagRepository.deleteByMybagId(mybagId);
 
-		return user.get().getUserEmail();
+		return user.getUserEmail();
 	}
 
-	// 물품 상태 변경
-	public String changeItemStatus(String accessToken, Long productId, int status) {
-		Optional<User> user = userRepository.findByAccessToken(accessToken);
-		user.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
-		Optional<Mybag> mybag = mybagRepository.findByUserAndProductId(user.get(), productId);
-		mybag.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
-		mybag.get().updateStatus(status);
+	// TODO: [front] mybag id로 물품 상태 변경
+	public String changeItemStatus(String accessToken, Long mybagId, int status) {
+		User user = userRepository.findByAccessToken(accessToken)
+			.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
+		Mybag mybag = mybagRepository.findByMybagId(mybagId)
+			.orElseThrow(() -> new CustomException(OBJECT_NOTFOUND_ERROR));
+		mybag.updateStatus(status);
 
-		return user.get().getUserEmail();
+		return user.getUserEmail();
 	}
 
 
-	//앞으로 절약할 가격 계산
+	// 앞으로 절약할 가격 계산
 	public Map<String, Integer> getPrice(String accessToken) {
 
 		Map<String, Integer> result = new HashMap<>();


### PR DESCRIPTION
## 작업 내용
장바구니 api 작업 시, `productId`가 아닌 `mybagId`로 동작하도록 수정
- [x] 물품 삭제 수정
- [x] 물품 상태 변경 수정
- [x] 물품 개수 변경 수정
- [ ]  postman 문서 수정
- [ ] 프론트 코드 수정

## 전달 사항
프론트에서 api 호출할 때 productId 기준으로 동작하게 되어있습니다.
현재 데모 페이지 작업으로 프론트 인력이 부족하다고 알고 있어서 상민님께 간단히 프론트 코드 수정방법 인계받은다음 PR 넣어 리뷰받는 방식으로 작업하면 어떨까 합니다.

## 궁금한 점

## 스크린샷 (선택)
