### PR TITLE
장바구니 productId 호출을 mybagId로 변경

### DIFF
--- a/frontend/src/Components/MyBag/BagProductList.js
+++ b/frontend/src/Components/MyBag/BagProductList.js
@@ -12,8 +12,8 @@ const BagProductList = ({
   return filterOption === PURCHASE_OPTION.BEFORE_PURCHASE
     ? wishList.map((item) => (
         <WishBagProduct
-          key={item.mybagId}
-          id={item.mybagId}
+          key={item.myBagId}
+          id={item.myBagId}
           product_name={item.productName}
           product_image={item.productImage}
           product_count={item.productCnt}
@@ -24,7 +24,7 @@ const BagProductList = ({
       ))
     : purchasedList.map((item) => (
         <PurchasedBagProduct
-          key={item.mybagId}
+          key={item.myBagId}
           product_name={item.productName}
           product_image={item.productImage}
           product_count={item.productCnt}

--- a/frontend/src/Components/MyBag/BagProductList.js
+++ b/frontend/src/Components/MyBag/BagProductList.js
@@ -12,8 +12,8 @@ const BagProductList = ({
   return filterOption === PURCHASE_OPTION.BEFORE_PURCHASE
     ? wishList.map((item) => (
         <WishBagProduct
-          key={item.productId}
-          id={item.productId}
+          key={item.mybagId}
+          id={item.mybagId}
           product_name={item.productName}
           product_image={item.productImage}
           product_count={item.productCnt}
@@ -24,7 +24,7 @@ const BagProductList = ({
       ))
     : purchasedList.map((item) => (
         <PurchasedBagProduct
-          key={item.productId}
+          key={item.mybagId}
           product_name={item.productName}
           product_image={item.productImage}
           product_count={item.productCnt}

--- a/frontend/src/Components/MyBag/MyBagContainer.js
+++ b/frontend/src/Components/MyBag/MyBagContainer.js
@@ -18,17 +18,17 @@ const MyBagContainer = ({
   const handleBuyClick = useCallback(async (event) => {
     const targetId = event.target.id;
     const words = targetId.split("&");
-    const productId = words[0].substr(words[0].indexOf("=") + 1);
+    const mybagId = words[0].substr(words[0].indexOf("=") + 1);
     const productName = words[2].substr(words[2].indexOf("=") + 1);
     setIsOpenModal(true);
-    setSelectedId(productId);
+    setSelectedId(mybagId);
     setBuyProductName(productName);
   }, []);
 
   const handleDeleteClick = useCallback(
     async (event) => {
       const targetId = event.target.id;
-      const productId = targetId.split("&")[0].split("=")[1];
+      const mybagId = targetId.split("&")[0].split("=")[1];
       /**
        * TODO #1
        * 정말로 삭제하시겠습니까?(React Toastify)
@@ -41,10 +41,10 @@ const MyBagContainer = ({
       // eslint-disable-next-line no-restricted-globals
       const ans = confirm("정말로 삭제하시겠습니까?");
       if (ans) {
-        const res = await dispatch(deleteWishProduct(productId));
+        const res = await dispatch(deleteWishProduct(mybagId));
         if (res.payload.status === 200) {
           const nextList = [...wishList, ...purchasedList];
-          setNextList(nextList, parseInt(productId));
+          setNextList(nextList, parseInt(mybagId));
           alert("삭제가 완료되었습니다.");
         }
       }

--- a/frontend/src/Components/MyBag/MyBagContainer.js
+++ b/frontend/src/Components/MyBag/MyBagContainer.js
@@ -18,17 +18,17 @@ const MyBagContainer = ({
   const handleBuyClick = useCallback(async (event) => {
     const targetId = event.target.id;
     const words = targetId.split("&");
-    const mybagId = words[0].substr(words[0].indexOf("=") + 1);
+    const myBagId = words[0].substr(words[0].indexOf("=") + 1);
     const productName = words[2].substr(words[2].indexOf("=") + 1);
     setIsOpenModal(true);
-    setSelectedId(mybagId);
+    setSelectedId(myBagId);
     setBuyProductName(productName);
   }, []);
 
   const handleDeleteClick = useCallback(
     async (event) => {
       const targetId = event.target.id;
-      const mybagId = targetId.split("&")[0].split("=")[1];
+      const myBagId = targetId.split("&")[0].split("=")[1];
       /**
        * TODO #1
        * 정말로 삭제하시겠습니까?(React Toastify)
@@ -41,10 +41,10 @@ const MyBagContainer = ({
       // eslint-disable-next-line no-restricted-globals
       const ans = confirm("정말로 삭제하시겠습니까?");
       if (ans) {
-        const res = await dispatch(deleteWishProduct(mybagId));
+        const res = await dispatch(deleteWishProduct(myBagId));
         if (res.payload.status === 200) {
           const nextList = [...wishList, ...purchasedList];
-          setNextList(nextList, parseInt(mybagId));
+          setNextList(nextList, parseInt(myBagId));
           alert("삭제가 완료되었습니다.");
         }
       }

--- a/frontend/src/Components/Util/useSetMyBagList.js
+++ b/frontend/src/Components/Util/useSetMyBagList.js
@@ -9,11 +9,11 @@ const useSetMyBagList = () => {
   const [wishList, setWishList] = useState([]);
   const [purchasedList, setPurchasedList] = useState([]);
 
-  const setNextList = (nextList, willUpdateStatusProductId) => {
+  const setNextList = (nextList, willUpdateStatusMybagId) => {
     const [nextWishList, nextPurchasedList] = nextList.reduce(
       ([wish, purchased], item) => {
         // 상태를 바꿔야 하는 품목만 상태 변경
-        if (item.productId === willUpdateStatusProductId) {
+        if (item.mybagId === willUpdateStatusMybagId) {
           item.status =
             item.status === PURCHASE_OPTION.BEFORE_PURCHASE
               ? PURCHASE_OPTION.AFTER_PURCHASE
@@ -37,6 +37,7 @@ const useSetMyBagList = () => {
         const itemNumberList = res.payload.data;
         const nextMyBagList = itemNumberList.map((item) => {
           return {
+            mybagId: item.id,
             productId: item.product.productId,
             productName: item.product.productName,
             productImage: item.product.productImage,

--- a/frontend/src/Components/Util/useSetMyBagList.js
+++ b/frontend/src/Components/Util/useSetMyBagList.js
@@ -9,11 +9,11 @@ const useSetMyBagList = () => {
   const [wishList, setWishList] = useState([]);
   const [purchasedList, setPurchasedList] = useState([]);
 
-  const setNextList = (nextList, willUpdateStatusMybagId) => {
+  const setNextList = (nextList, willUpdateStatusMyBagId) => {
     const [nextWishList, nextPurchasedList] = nextList.reduce(
       ([wish, purchased], item) => {
         // 상태를 바꿔야 하는 품목만 상태 변경
-        if (item.mybagId === willUpdateStatusMybagId) {
+        if (item.myBagId === willUpdateStatusMyBagId) {
           item.status =
             item.status === PURCHASE_OPTION.BEFORE_PURCHASE
               ? PURCHASE_OPTION.AFTER_PURCHASE
@@ -37,7 +37,7 @@ const useSetMyBagList = () => {
         const itemNumberList = res.payload.data;
         const nextMyBagList = itemNumberList.map((item) => {
           return {
-            mybagId: item.id,
+            myBagId: item.id,
             productId: item.product.productId,
             productName: item.product.productName,
             productImage: item.product.productImage,

--- a/frontend/src/Store/Actions/productAction.js
+++ b/frontend/src/Store/Actions/productAction.js
@@ -25,8 +25,8 @@ export const wishProduct = async (body, id) => {
   };
 };
 
-export const deleteWishProduct = async (id) => {
-  const res = await request.delete(`/api/mybag/delete/${id}`);
+export const deleteWishProduct = async (mybagId) => {
+  const res = await request.delete(`/api/mybag/delete/${mybagId}`);
 
   return {
     type: DELETE_PRODUCT,
@@ -45,8 +45,8 @@ export const getProductList = async (mart, searchKeyword, page, sortFilter) => {
   };
 };
 
-export const changeMyBagState = async (productId, body) => {
-  const res = await request.patch(`/api/mybag/changestat/${productId}`, body);
+export const changeMyBagState = async (mybagId, body) => {
+  const res = await request.patch(`/api/mybag/changestat/${mybagId}`, body);
 
   return {
     type: GET_PRODUT_LIST,
@@ -63,8 +63,8 @@ export const getMyBagList = async () => {
   };
 };
 
-export const changeMyBagCnt = async (prodcutId, body) => {
-  const res = await request.post(`/api/mybag/changecnt/${prodcutId}`, body);
+export const changeMyBagCnt = async (mybagId, body) => {
+  const res = await request.post(`/api/mybag/changecnt/${mybagId}`, body);
 
   return {
     type: CHANGE_MY_BAG_PRODUCT_CNT,

--- a/frontend/src/Store/Actions/productAction.js
+++ b/frontend/src/Store/Actions/productAction.js
@@ -25,8 +25,8 @@ export const wishProduct = async (body, id) => {
   };
 };
 
-export const deleteWishProduct = async (mybagId) => {
-  const res = await request.delete(`/api/mybag/delete/${mybagId}`);
+export const deleteWishProduct = async (myBagId) => {
+  const res = await request.delete(`/api/mybag/delete/${myBagId}`);
 
   return {
     type: DELETE_PRODUCT,
@@ -45,8 +45,8 @@ export const getProductList = async (mart, searchKeyword, page, sortFilter) => {
   };
 };
 
-export const changeMyBagState = async (mybagId, body) => {
-  const res = await request.patch(`/api/mybag/changestat/${mybagId}`, body);
+export const changeMyBagState = async (myBagId, body) => {
+  const res = await request.patch(`/api/mybag/changestat/${myBagId}`, body);
 
   return {
     type: GET_PRODUT_LIST,
@@ -63,8 +63,8 @@ export const getMyBagList = async () => {
   };
 };
 
-export const changeMyBagCnt = async (mybagId, body) => {
-  const res = await request.post(`/api/mybag/changecnt/${mybagId}`, body);
+export const changeMyBagCnt = async (myBagId, body) => {
+  const res = await request.post(`/api/mybag/changecnt/${myBagId}`, body);
 
   return {
     type: CHANGE_MY_BAG_PRODUCT_CNT,


### PR DESCRIPTION
## 작업 내용
장바구니 물품 삭제, 물품 구매를 productId가 아니라 mybagId로 수행하도록 변경
- [x] 장바구니 물품 삭제, 물품 구매를 mybagId로 호출하도록 변경
- [x] 장바구니 리스트 만드는 `useSetMybagList.js`에서 mybagId를 받도록 인자 추가
- [x] api 호출부(`productAction.js`)에 id, mybagId, productId가 헷갈려서 명확하게 mybagId인 것은 변수명 변경

## 전달 사항
추후 장바구니 물품 상태 변경, 물품 개수 변경 api를 따로 호출하도록 코드 변경할 때 `productId`가 아니라 `mybagId`임을 주의해야 할 것 같습니다.

## 궁금한 점
useSetMyBagList.js의 `willUpdateStatusProductId`의 동작 방식을 잘 모르겠어서 일단 `willUpdateStatusMybagId`로 변경해두었습니다... 어떻게 사용하는건지 알 수 있을까요?!

## 스크린샷 (선택)
