### PR TITLE
모바일 Product List 재스타일링

### DIFF
--- a/frontend/src/Components/Product/ProductPresenter.js
+++ b/frontend/src/Components/Product/ProductPresenter.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { Link } from "react-router-dom";
 import { useDispatch } from "react-redux";
-import { Grid, Button } from "@material-ui/core";
+import { Grid } from "@material-ui/core";
 import { CU, SEVEN_ELEVEN, GS25, EMART24 } from "../Util/Constant";
 import { selectProduct } from "../../Store/Actions/productAction";
 import addComma from "../Util/AddComma";
@@ -40,31 +40,30 @@ const ProductPresenter = ({
     default:
       break;
   }
+
   const onClick = useCallback(() => {
     dispatch(selectProduct(productInfo));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
+
   return (
-    <Grid className="product-container">
+    <Link className="product-container" to={`/list/${id}`} onClick={onClick}>
       <Grid className="product-image-container">
         <img src={product_image} alt={product_name} />
       </Grid>
       <Grid className="product-info-container">
-        <Grid className="product-info-price-container">
-          <span>
-            {`${addComma(sale_price)}`}
-            <del>{addComma(original_price)}</del>
-          </span>
+        <Grid className="product-info-price-name-container">
+          <Grid className="product-info-price-container">
+            <span>
+              {`${addComma(sale_price)}원`}
+              <del>{addComma(original_price)}</del>
+            </span>
+          </Grid>
+          <span className="product-info-text"> {product_name} </span>
         </Grid>
-        <span className="product-info-text"> {product_name} </span>
         <span className={martClass}> {mart_name} </span>
       </Grid>
-      <Link className="product-button" to={`/list/${id}`}>
-        <Button onClick={onClick} variant="contained">
-          자세히
-        </Button>
-      </Link>
-    </Grid>
+    </Link>
   );
 };
 

--- a/frontend/src/scss/Layout.scss
+++ b/frontend/src/scss/Layout.scss
@@ -11,6 +11,11 @@
 @import "./components/sideMenuBtn";
 @import "./components/logoutToast";
 
+a {
+  text-decoration: none;
+  color: $black;
+}
+
 body {
   font-family: "Noto Sans KR", sans-serif;
 }
@@ -35,6 +40,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: space-between;
   width: 100%;
 
   .MuiGrid-root {

--- a/frontend/src/scss/components/_martLabel.scss
+++ b/frontend/src/scss/components/_martLabel.scss
@@ -2,6 +2,7 @@
   @include font-default(400, 0.7rem);
   padding: 0.1rem 0.4rem 0.1rem 0.4rem;
   width: 3rem;
+  height: 1.2rem;
   text-align: center;
   border-radius: 1rem;
   color: $black;

--- a/frontend/src/scss/components/_martList.scss
+++ b/frontend/src/scss/components/_martList.scss
@@ -36,12 +36,13 @@
     top: 0;
     z-index: 7;
     background-color: rgba(0, 0, 0, 0.8);
-    width: 100%;
-    height: 100%;
+    width: 100vw;
+    height: 90vh;
+    gap: 1rem;
     align-items: center;
-    span {
-      position: absolute;
-      bottom: 20%;
+    justify-content: flex-end;
+    padding-bottom: 10vh;
+    & > span {
       color: $white;
     }
   }
@@ -87,9 +88,8 @@
   @include mobile {
     display: flex;
     width: 100%;
+    height: 80px;
     justify-content: space-evenly;
-    position: absolute;
-    bottom: 10%;
   }
   @include desktop {
     display: flex;

--- a/frontend/src/scss/components/_product.scss
+++ b/frontend/src/scss/components/_product.scss
@@ -1,11 +1,10 @@
 .product-container {
   display: flex;
   flex-direction: row;
+  align-items: center;
+  width: 100%;
   height: 5rem;
-  border-bottom: 2px solid $line;
-  a {
-    text-decoration: none;
-  }
+  border-bottom: 1px solid $line;
   @include desktop {
     flex-direction: column;
     width: 12rem;
@@ -13,6 +12,7 @@
     border: 2px solid $line;
   }
 }
+
 .product-image-container {
   @include mobile {
     display: flex;
@@ -33,49 +33,62 @@
     border-bottom: 2px solid $line;
   }
 }
+
 .product-info-container {
   @include mobile {
     display: flex;
-    justify-content: space-evenly;
-    width: 60%;
-    flex-direction: column;
-    padding-left: 0.5rem;
-    .product-info-text {
+    align-items: center;
+    height: 100%;
+    width: 80%;
+    padding: 0 0.5rem;
+
+    .product-info-price-name-container {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-around;
+      width: 80%;
+      height: 100%;
+    }
+
+    .product-info-name {
       height: 1rem;
       overflow: hidden;
       line-height: 1;
     }
   }
   @include desktop {
-    width: 100%;
-    height: 100%;
+    width: calc(100% - 0.8rem);
+    height: calc(100% - 0.8rem);
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    align-items: flex-end;
     padding: 0.4rem;
+
+    .product-info-price-name-container {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-around;
+      width: 100%;
+      height: 100%;
+    }
   }
 }
+
 .product-info-price-container {
-  display: flex;
-  flex-direction: row;
   span {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.4rem;
+    color: $error;
     @include font-default(400, 1rem);
     del {
       @include font-default(400, 0.8rem);
+      color: $success;
       @include desktop {
         margin-left: 0.2rem;
       }
     }
-  }
-}
-.product-button {
-  display: flex;
-  width: 20%;
-  .MuiButton-label {
-    font-size: 0.8rem;
-  }
-  @include desktop {
-    display: none;
   }
 }
 .product-search-result-container {

--- a/frontend/src/scss/components/_sideMenu.scss
+++ b/frontend/src/scss/components/_sideMenu.scss
@@ -8,7 +8,6 @@
   div {
     display: flex;
     flex-direction: column;
-    text-decoration: none;
     margin-top: 1.5rem;
 
     @include mobile {


### PR DESCRIPTION
## 작업 내용

- [x] `자세히` 버튼을 없애고 어딜 눌러도 상세 페이지로 이동하게끔 함
- [x] `자세히` 버튼을 없앰에 따라 마트 라벨을 오른쪽으로 배치
- [x] 가격에 색깔입힘
- [x] 구분선 2px => 1px로 수정
- [x] 리스트와 헤더 사이에 1rem 정도 붕 떴었던거 제거
- [x] 그 외 조금씩 거슬리던 거 수정

## 전달 사항

`자세히` 버튼을 없애자는 이유
- 예전에 논의했을 때에는 기능의 목적을 명확하게 전달하기 위해 필요하다고 판단했었음
- 지금은 시각적으로도 별로고 제품 정보인 가격 / 이름 / 마트 세 가지를 한 칸에 채우다보니까 복잡스러움
- `자세히` 버튼만 없애면 제품 정보도 조금 더 널널하게 배치할 수 있고 여백이 많으니까 덜 부담스럽게 보이는듯?

가격에 색깔을 입힌 이유
- 제품 이름보다 가격을 먼저 적게 한 것부터 우리 서비스의 목적인 할인 정보를 전달하는 것과 부합하다고 생각함
- 그런데 제품 이름과 가격이 모두 검정색일 경우, 가격 정보가 한 눈에 들어오지 않음
- 그렇다고 제품 이름에 색깔을 입히면, 이름이 강조가 되기 때문에 앞서 말한 할인 정보 전달에서 어긋나는 방향 같음
- 따라서 가격에 색깔을 입히되 할인된 가격을 좀 더 강조하고자 붉은색 `$error` 을 입히고, 원래 가격은 상대적으로 눈에 덜 띄는 푸른색 `$success` 을 입힘

## 궁금한 점

`Components/ProductPresenter.js`에서 `onClick`의 역할이 뭐였는지 기억하시나요? (자세히 버튼 누르면 발동하는 이벤트)
이게 없어도 상세 페이지 무리 없이 작동하던데, 장바구니에서 쓰였던가요? 일단 혹시 몰라서 남겨두긴 했습니다!!

## 스크린샷 (선택)

왼쪽 before
오른쪽 after

<div style="display: flex">

<img width="40%" src="https://user-images.githubusercontent.com/42960217/153124594-c5f45381-4101-44c1-bcea-1704812d86ab.png" />

<img width="40%" src="https://user-images.githubusercontent.com/42960217/153124577-b2197a2b-9f17-4549-aae8-1a54299c3677.png" />

</div>
