### PR TITLE
[Fix] css 지정자 변경

### DIFF
--- a/frontend/src/scss/components/_product.scss
+++ b/frontend/src/scss/components/_product.scss
@@ -144,8 +144,7 @@
           opacity: 0.4;
         }
       }
-
-      .PrivateTabIndicator-colorSecondary-7 {
+      .MuiTabs-indicator {
         // 빨간 밑줄
         display: none;
       }
@@ -159,9 +158,8 @@
       background-color: $background;
       color: $black;
     }
-    .PrivateTabIndicator-colorSecondary-7 {
+    .MuiTabs-indicator {
       height: 4px;
-      //background-color: $black;
     }
     .MuiTabs-root {
       min-height: 2.5rem;


### PR DESCRIPTION
## 작업 내용

- [x] 지정자 변경

## 전달 사항

정렬 버튼 밑에 빨간 줄은 정렬 탭을 임의로 바꾸다 보니 위치랑 크기를 마음대로 제어할 수 없어 의도적으로 없앴는데 배포된 후 확인해보니 남아있더라구요!

확인 결과 `.PrivateTabIndicator-colorSecondary-7`이라는 class가 배포시 `.jss7`로 바뀌는 문제를 발견해
배포 후에도 남아있는 `.MuiTabs-indicator`로 지정자를 변경했습니다!

+ 모바일에서도 빨간 줄이 원래 두꺼워야하는데 얇았던 이유도 이거였을 것 같아용

## 스크린샷 (선택)
