### PR TITLE
[Fix][Feat] 상품 이미지 깨지는 것 해결 + 레이아웃 수정

### DIFF
--- a/frontend/src/Components/ProductList/ProductListPresenter.js
+++ b/frontend/src/Components/ProductList/ProductListPresenter.js
@@ -7,19 +7,21 @@ const ProductListPresenter = ({ list, listComponent, isLoading }) => {
   return (
     <main className="product-list-container-container">
       <div className="product-list-container" ref={listComponent}>
-        {list.map((item) => {
-          return (
-            <Product
-              key={item.productId}
-              id={item.productId}
-              mart_name={item.martName}
-              product_name={item.productName}
-              product_image={item.productImage}
-              original_price={item.originalPrice}
-              sale_price={item.salePrice}
-            />
-          );
-        })}
+        <div className="product-list">
+          {list.map((item) => {
+            return (
+              <Product
+                key={item.productId}
+                id={item.productId}
+                mart_name={item.martName}
+                product_name={item.productName}
+                product_image={item.productImage}
+                original_price={item.originalPrice}
+                sale_price={item.salePrice}
+              />
+            );
+          })}
+        </div>
       </div>
       {isLoading && <Loading />}
     </main>

--- a/frontend/src/scss/Layout.scss
+++ b/frontend/src/scss/Layout.scss
@@ -45,6 +45,7 @@ body {
   @include desktop {
     box-shadow: 0 5px 4px rgba(0, 0, 0, 0.25);
     margin-bottom: 1rem;
+    z-index: 5;
   }
   .MuiGrid-root {
     width: 100%;

--- a/frontend/src/scss/ProductList.scss
+++ b/frontend/src/scss/ProductList.scss
@@ -1,4 +1,4 @@
-// Login page scss
+// Product List page scss
 
 // default scss
 @import "./base/base";
@@ -9,18 +9,25 @@
 @import "./components/product";
 @import "./components/martLabel";
 
-.product-list-container {
+.product-list {
   display: flex;
-  overflow-y: scroll;
   width: 100%;
   flex-direction: column;
   @include desktop {
-    display: grid;
-    height: 100%;
-    grid-template-columns: repeat(5, 1fr);
-    justify-items: center;
+    flex-wrap: wrap;
+    flex-direction: row;
+    width: calc(100% - 2rem);
+    justify-content: space-evenly;
     gap: 1rem;
+    padding: 1rem;
+  }
+}
 
+.product-list-container {
+  @include desktop {
+    width: 100%;
+    height: 100%;
+    overflow-y: scroll;
     &::-webkit-scrollbar {
       width: 0.5rem;
     }
@@ -35,17 +42,21 @@
       background: none;
     }
   }
+  @include mobile {
+    overflow-y: scroll;
+  }
 }
 
 .product-list-container-container {
-  position: relative;
   @include desktop {
-    width: 100%;
-    overflow-y: hidden;
+    position: relative;
+    overflow: hidden;
+    margin-top: -1rem; // negative margin
   }
   @include mobile {
+    position: relative;
     display: flex;
-    overflow-y: scroll;
+    overflow-y: hidden;
     width: 100%;
     flex-direction: column;
   }

--- a/frontend/src/scss/components/_product.scss
+++ b/frontend/src/scss/components/_product.scss
@@ -10,6 +10,12 @@
     width: 12rem;
     height: 18rem;
     border: 2px solid $line;
+    border-radius: 10px;
+    overflow: hidden;
+    &:hover {
+      transform: scale(1.05);
+    }
+    transition: all 0.3s ease-in-out;
   }
 }
 

--- a/frontend/src/scss/components/_product.scss
+++ b/frontend/src/scss/components/_product.scss
@@ -31,11 +31,15 @@
     }
   }
   @include desktop {
+    display: flex;
     width: 100%;
+    min-height: 10rem;
+    max-height: 10rem;
+    align-items: center;
+    justify-content: center;
     img {
-      width: 100%;
-      height: 100%;
-      max-height: 10em;
+      max-width: 100%;
+      max-height: 8rem;
     }
     border-bottom: 2px solid $line;
   }
@@ -65,8 +69,8 @@
   }
   @include desktop {
     width: calc(100% - 0.8rem);
-    height: calc(100% - 0.8rem);
     display: flex;
+    flex-grow: 1;
     flex-direction: column;
     align-items: flex-end;
     padding: 0.4rem;


### PR DESCRIPTION
## 작업 내용

- [x] 상품 이미지 크기 고정
- [x] 상품 hover 애니메이션
- [x] grid => flex로 레이아웃 변경(이슈 있음)

## 전달 사항

- 상품 이미지가 아래 스크린샷과 같이 이미지 크기 고정이 필요해 고정하였습니다.

![image](https://user-images.githubusercontent.com/42960217/158058433-7c99c28f-9648-4fd8-a152-6c3360e63e67.png)

<br />
<br />

- grid => flex로 레이아웃을 변경하면서, 화면 크기가 커지면 커진 만큼 한 행에 많은 상품을 보여줄 수 있어졌고, 작아지면 작아진 만큼 적은 상품을 보여줄 수 있는데 결국 아래 이슈는 해결하지 못했습니다.
  - 아래까지 닿으면 무한 스크롤이 있기 때문에 크게 티가 안난다고 생각했는데, 검색을 해서 제한된 개수의 상품을 보여줄 경우에는 티나버려요..

![image](https://user-images.githubusercontent.com/42960217/158058340-1e5f0f47-ae00-445f-9f8e-8c15f25fb86d.png)

- 이렇게 레이아웃을 변경하면서 본 게, `.product-list-container`와 `.product-list-container-container`가 있었는데 `.product-list-container-container`에는 `overflow: hidden;`을 주고,  `.product-list-container`는 `product`들의 리스트면서 `overflow: scroll;`을 준 게 뭔가 어색한 구조라고 생각했어요.
  - 그래서 `.product-list` / `.product-list-container` / `.product-list-container-container` 세 개로 나눴습니다.
    - `.product-list` : `product`들의 부모 요소. 크기를 제한하지 않은 날 것 그 상태
    - `.product-list-container` : `.product-list`의 부모 요소. `overflow: scroll;` 부여
    - `.product-list-container-container`: `.product-list-container`의 부모 요소. `overflow: hidden;` 부여
      - 이 구조가 필요한 이유는, 로딩 컴포넌트 위치 잡는 게 빡센 것도 있고 나중에 좀 더 수정하기 편할 것 같더라구요!