### PR TITLE
[Refactor] 인피니티스크롤 모듈화 및 간단한 레이아웃

### DIFF
--- a/frontend/src/Components/Hook/useInfiniteScroll.js
+++ b/frontend/src/Components/Hook/useInfiniteScroll.js
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+
+import { throttle } from "../Util/Throttle";
+
+/**
+ * scroll이벤트를 다룹니다.
+ * listRef의 최하단에 스크롤이 갔을 경우, 새로운 리스트를 불러옵니다.
+ * @returns [listRef] listRef: 리스트 컴포넌트에 붙일 ref
+ */
+const useInfiniteScroll = ({ isLoadFinish, getList }) => {
+  const listRef = useRef();
+
+  const checkScroll = () => {
+    if (!listRef.current) return;
+    const scrollHeight = listRef?.current.scrollHeight;
+    const scrollTop = listRef?.current.scrollTop;
+    const clientHeight = listRef?.current.clientHeight;
+
+    if (scrollTop + clientHeight >= scrollHeight) {
+      if (!isLoadFinish) {
+        getList();
+      }
+    }
+  };
+
+  const handleScroll = throttle(checkScroll, 500);
+
+  useEffect(() => {
+    listRef?.current?.addEventListener("scroll", handleScroll);
+
+    return () => {
+      if (listRef.current)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        listRef?.current.removeEventListener("scroll", handleScroll);
+    };
+  }, [handleScroll]);
+
+  return [listRef];
+};
+
+export default useInfiniteScroll;

--- a/frontend/src/Components/Hook/useLoadData.js
+++ b/frontend/src/Components/Hook/useLoadData.js
@@ -1,0 +1,121 @@
+import { useState, useRef, useCallback, useLayoutEffect } from "react";
+import { useDispatch } from "react-redux";
+
+import { getProductList } from "../../Store/Actions/productAction";
+import { SORT_OPTION } from "../Util/Constant";
+
+const getMartCode = (martList) => {
+  const tempMartCode = Object.values(martList)
+    .map((flag) => {
+      return flag === true ? "1" : "0";
+    })
+    .join("");
+  return tempMartCode;
+};
+
+/**
+ * @param searchKeyword 유저가 입력한 검색어
+ * @param sortOption 이름순인지, 가격순인지 정렬
+ * @param martList 유저가 선택한 mart
+ * @returns [list, getList, isLoadFinish, isSpinnerActive]
+ *
+ * list: 아이템을 담은 배열입니다. <br />
+ *
+ * getList: 아이템을 받는 함수입니다. (useInfiniteScroll에서 사용됩니다.)
+ *
+ * isLoadFinish: 아이템을 더 받을 수 있는지 알려줍니다. (useInfiniteScroll에서 사용됩니다.)
+ *
+ * isSpinnerActive: getList를 하는 중인지 알려줍니다. (loading이 되고 있는지)
+ */
+const useLoadData = ({ searchKeyword, sortOption, martList }) => {
+  const [list, setList] = useState([]); // 반환될 리스트
+  const [isLoadFinish, setIsLoadFinish] = useState(false); // 전체 리스트를 모두 가져왔는지
+  const [isSpinnerActive, setIsSpinnerActive] = useState(false); // 스피너
+  const [isFirstRender, setIsFirstRender] = useState(true); //
+  const [lastPage, setLastPage] = useState(100);
+  const [finalKeyword, setFinalKeyword] = useState(searchKeyword) || "";
+  const [finalOption, setFinalOption] = useState(sortOption);
+  const [finalMartCode, setFinalMartCode] = useState("");
+  const [isOptionChanged, setIsOptionChaged] = useState(false);
+  const currentPage = useRef(0);
+  const martCode = useRef(getMartCode(martList));
+  const dispatch = useDispatch();
+
+  const getList = useCallback(async () => {
+    // 로딩이 끝난 경우
+    if (isLoadFinish || currentPage.current >= lastPage) return;
+    setIsSpinnerActive(true); // 스피너 On
+    // 리스트 받아오기
+    const filter =
+      finalOption === SORT_OPTION.SALE_PRICE ? "salePrice" : "productName";
+    const res = await dispatch(
+      getProductList(
+        martCode.current,
+        finalKeyword,
+        currentPage.current,
+        filter
+      )
+    );
+    const { data, status } = res.payload;
+    // success
+    if (status === 200) {
+      setList((prev) => [...prev, ...data.content]);
+      currentPage.current++;
+      if (currentPage.current > lastPage) {
+        setIsLoadFinish(true);
+      }
+      setLastPage(data.totalPages > 0 ? data.totalPages : 100);
+    }
+    setIsSpinnerActive(false); // 스피너 Off
+  }, [dispatch, finalKeyword, finalOption, isLoadFinish, lastPage]);
+
+  const setInitialValue = useCallback(() => {
+    setFinalKeyword(() => searchKeyword);
+    setFinalOption(() => sortOption);
+    currentPage.current = 0;
+    setList(() => []);
+    setIsFirstRender(true);
+    setIsLoadFinish(false);
+    martCode.current = getMartCode(martList);
+    setFinalMartCode(martCode.current);
+  }, [martList, searchKeyword, setFinalKeyword, sortOption]);
+
+  const getIsOptionChanged = useCallback(() => {
+    return (
+      searchKeyword !== finalKeyword ||
+      finalOption !== sortOption ||
+      martCode.current !== finalMartCode
+    );
+  }, [finalKeyword, finalMartCode, finalOption, searchKeyword, sortOption]);
+
+  // Infinite Scroll
+  useLayoutEffect(() => {
+    // 마트코드/검색어/필터가 달라졌다면 스크롤과 상관없이 상품을 가져온다.
+    // 처음으로 리스트에 접근했다면 스크롤과 상관없이 상품을 가져온다.
+    if (isOptionChanged || isFirstRender) {
+      setInitialValue();
+      setIsFirstRender(false);
+      getList();
+    }
+  }, [
+    searchKeyword,
+    finalOption,
+    martCode,
+    getList,
+    isFirstRender,
+    isOptionChanged,
+    setInitialValue,
+  ]);
+
+  // setMartCode before render
+  useLayoutEffect(() => {
+    martCode.current = getMartCode(martList);
+    currentPage.current = 0;
+    setFinalMartCode(martCode.current);
+    setIsOptionChaged(() => getIsOptionChanged());
+  }, [getIsOptionChanged, martCode, martList]);
+
+  return [list, getList, isSpinnerActive, isLoadFinish];
+};
+
+export default useLoadData;

--- a/frontend/src/Components/Hook/useLoadData.js
+++ b/frontend/src/Components/Hook/useLoadData.js
@@ -36,7 +36,6 @@ const useLoadData = ({ searchKeyword, sortOption, martList }) => {
   const [finalKeyword, setFinalKeyword] = useState(searchKeyword) || "";
   const [finalOption, setFinalOption] = useState(sortOption);
   const [finalMartCode, setFinalMartCode] = useState("");
-  const [isOptionChanged, setIsOptionChaged] = useState(false);
   const currentPage = useRef(0);
   const martCode = useRef(getMartCode(martList));
   const dispatch = useDispatch();
@@ -69,50 +68,43 @@ const useLoadData = ({ searchKeyword, sortOption, martList }) => {
     setIsSpinnerActive(false); // 스피너 Off
   }, [dispatch, finalKeyword, finalOption, isLoadFinish, lastPage]);
 
-  const setInitialValue = useCallback(() => {
-    setFinalKeyword(() => searchKeyword);
-    setFinalOption(() => sortOption);
-    currentPage.current = 0;
-    setList(() => []);
-    setIsFirstRender(true);
-    setIsLoadFinish(false);
-    martCode.current = getMartCode(martList);
-    setFinalMartCode(martCode.current);
-  }, [martList, searchKeyword, setFinalKeyword, sortOption]);
-
-  const getIsOptionChanged = useCallback(() => {
-    return (
+  // Page Load Data 연결
+  useLayoutEffect(() => {
+    if (
       searchKeyword !== finalKeyword ||
       finalOption !== sortOption ||
-      martCode.current !== finalMartCode
-    );
-  }, [finalKeyword, finalMartCode, finalOption, searchKeyword, sortOption]);
+      getMartCode(martList) !== martCode.current
+    ) {
+      setFinalKeyword(() => searchKeyword);
+      setFinalOption(() => sortOption);
+      currentPage.current = 0;
+      martCode.current = getMartCode(martList);
+      setList(() => []);
+      setIsFirstRender(true);
+      setIsLoadFinish(false);
+      setFinalMartCode(martCode.current);
+    }
 
-  useLayoutEffect(() => {
-    // 마트코드/검색어/필터가 달라졌다면 스크롤과 상관없이 상품을 가져온다.
-    // 처음으로 리스트에 접근했다면 스크롤과 상관없이 상품을 가져온다.
-    if (isOptionChanged || isFirstRender) {
-      setInitialValue();
-      setIsFirstRender(false);
+    // 처음 렌더가 되는 거라면 스크롤과 상관 없이 상품을 가져온다.
+    if (isFirstRender) {
       getList();
+      setIsFirstRender(false);
     }
   }, [
-    searchKeyword,
-    finalOption,
-    martCode,
-    getList,
+    dispatch,
     isFirstRender,
-    isOptionChanged,
-    setInitialValue,
+    isLoadFinish,
+    lastPage,
+    list,
+    finalKeyword,
+    sortOption,
+    searchKeyword,
+    setFinalKeyword,
+    finalOption,
+    finalMartCode,
+    martList,
+    getList,
   ]);
-
-  // setMartCode before render
-  useLayoutEffect(() => {
-    martCode.current = getMartCode(martList);
-    currentPage.current = 0;
-    setFinalMartCode(martCode.current);
-    setIsOptionChaged(() => getIsOptionChanged());
-  }, [getIsOptionChanged, martCode, martList]);
 
   return [list, getList, isSpinnerActive, isLoadFinish];
 };

--- a/frontend/src/Components/Hook/useLoadData.js
+++ b/frontend/src/Components/Hook/useLoadData.js
@@ -19,7 +19,7 @@ const getMartCode = (martList) => {
  * @param martList 유저가 선택한 mart
  * @returns [list, getList, isLoadFinish, isSpinnerActive]
  *
- * list: 아이템을 담은 배열입니다. <br />
+ * list: 아이템을 담은 배열입니다.
  *
  * getList: 아이템을 받는 함수입니다. (useInfiniteScroll에서 사용됩니다.)
  *
@@ -28,10 +28,10 @@ const getMartCode = (martList) => {
  * isSpinnerActive: getList를 하는 중인지 알려줍니다. (loading이 되고 있는지)
  */
 const useLoadData = ({ searchKeyword, sortOption, martList }) => {
-  const [list, setList] = useState([]); // 반환될 리스트
-  const [isLoadFinish, setIsLoadFinish] = useState(false); // 전체 리스트를 모두 가져왔는지
-  const [isSpinnerActive, setIsSpinnerActive] = useState(false); // 스피너
-  const [isFirstRender, setIsFirstRender] = useState(true); //
+  const [list, setList] = useState([]);
+  const [isLoadFinish, setIsLoadFinish] = useState(false);
+  const [isSpinnerActive, setIsSpinnerActive] = useState(false);
+  const [isFirstRender, setIsFirstRender] = useState(true);
   const [lastPage, setLastPage] = useState(100);
   const [finalKeyword, setFinalKeyword] = useState(searchKeyword) || "";
   const [finalOption, setFinalOption] = useState(sortOption);
@@ -88,7 +88,6 @@ const useLoadData = ({ searchKeyword, sortOption, martList }) => {
     );
   }, [finalKeyword, finalMartCode, finalOption, searchKeyword, sortOption]);
 
-  // Infinite Scroll
   useLayoutEffect(() => {
     // 마트코드/검색어/필터가 달라졌다면 스크롤과 상관없이 상품을 가져온다.
     // 처음으로 리스트에 접근했다면 스크롤과 상관없이 상품을 가져온다.

--- a/frontend/src/Components/Hook/useSetMyBagList.js
+++ b/frontend/src/Components/Hook/useSetMyBagList.js
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { useDispatch } from "react-redux";
+
 import { getMyBagList } from "../../Store/Actions/productAction";
-import { PURCHASE_OPTION } from "./Constant";
+import { PURCHASE_OPTION } from "../Util/Constant";
 
 const useSetMyBagList = () => {
   const dispatch = useDispatch();

--- a/frontend/src/Components/Layout/SideMenu/SideMenuPresenter.js
+++ b/frontend/src/Components/Layout/SideMenu/SideMenuPresenter.js
@@ -13,9 +13,11 @@ const SideMenuPresenter = ({
   return (
     <>
       <div className={`sidemenu-container ${showSideMenu || "sidemenu-hide"}`}>
-        <header className="logo">
-          <img alt="logo" src="/img/logo_long_no_empty.png" />
-        </header>
+        <Link to="/main" onClick={handleLink}>
+          <header className="logo">
+            <img alt="logo" src="/img/logo_long_no_empty.png" />
+          </header>
+        </Link>
         <nav className="sidemenu-nav">
           <Link to="/main" onClick={handleLink}>
             홈

--- a/frontend/src/Components/MyBag/BuyModal/BuyModalContainer.js
+++ b/frontend/src/Components/MyBag/BuyModal/BuyModalContainer.js
@@ -69,8 +69,12 @@ const BuyModalContainer = ({
     }
 
     // update entire list
+    // status : isCntChange -> BEFORE_PURCHASE, !isCntChange -> AFTER_PURCHASE
+    // isCntChange -> item.productCnt == 0 -> DELETE_PURCHASE
     const nextStatus = isCntChange
-      ? PURCHASE_OPTION.BEFORE_PURCHASE
+      ? item.productCnt === 0
+        ? PURCHASE_OPTION.DELETE_PURCHASE
+        : PURCHASE_OPTION.BEFORE_PURCHASE
       : PURCHASE_OPTION.AFTER_PURCHASE;
     const nextList = getUpdatedNextList(
       wishList,

--- a/frontend/src/Components/ProductList/ProductListContainer.js
+++ b/frontend/src/Components/ProductList/ProductListContainer.js
@@ -1,129 +1,20 @@
-import React, { useRef, useState, useEffect, useLayoutEffect } from "react";
-import { useDispatch } from "react-redux";
-
 import ProductListPresenter from "./ProductListPresenter";
-import { getProductList } from "../../Store/Actions/productAction";
-import { throttle } from "../Util/Throttle";
-
-const getMartCode = (martList) => {
-  const tempMartCode = Object.values(martList)
-    .map((flag) => {
-      return flag === true ? "1" : "0";
-    })
-    .join("");
-  return tempMartCode;
-};
+import useInfiniteScroll from "../Hook/useInfiniteScroll";
+import useLoadData from "../Hook/useLoadData";
 
 const ProductListContainer = ({ martList, searchKeyword, sortOption }) => {
-  const [list, setList] = useState([]);
-  const [isLoadFinish, setIsLoadFinish] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isFirstRender, setIsFirstRender] = useState(true);
-  const [lastPage, setLastPage] = useState(100);
-  const [finalKeyword, setFinalKeyword] = useState(searchKeyword) || "";
-  const [finalOption, setFinalOption] = useState(sortOption);
-  const [finalMartCode, setFinalMartCode] = useState("");
-  const currentPage = useRef(0);
-  const listComponent = useRef(0);
-  const martCode = useRef("");
-  const dispatch = useDispatch();
-
-  // Infinite Scroll
-  useEffect(() => {
-    const getList = async () => {
-      // 상품 마지막 페이지에 도착했을 경우
-      if (currentPage.current >= lastPage) return;
-      if (isLoadFinish) return;
-      const filter = finalOption === 1 ? "salePrice" : "productName";
-      setIsLoading(true); // 스피너 On
-      const res = await dispatch(
-        getProductList(
-          martCode.current,
-          finalKeyword,
-          currentPage.current,
-          filter
-        )
-      );
-      const data = res.payload.data;
-      if (res.payload.status === 200) {
-        setList((prev) => [...prev, ...data.content]);
-        currentPage.current++;
-
-        if (currentPage.current > lastPage) {
-          setIsLoadFinish(true);
-        }
-        setLastPage(data.totalPages > 0 ? data.totalPages : 100);
-      }
-      setIsLoading(false); // 스피너 Off
-    };
-
-    const checkScroll = () => {
-      const scrollHeight = listComponent?.current.scrollHeight;
-      const scrollTop = listComponent?.current.scrollTop;
-      const clientHeight = listComponent?.current.clientHeight;
-
-      if (scrollTop + clientHeight >= scrollHeight) {
-        if (!isLoadFinish) {
-          getList();
-        }
-      }
-    };
-
-    const handleScroll = throttle(checkScroll, 500);
-    listComponent.current.addEventListener("scroll", handleScroll);
-
-    // 마트코드/검색어/ 필터가 달라졌다면 스크롤과 상관 없이 상품을 가져온다.
-    if (
-      searchKeyword !== finalKeyword ||
-      finalOption !== sortOption ||
-      martCode.current !== finalMartCode
-    ) {
-      setFinalKeyword(() => searchKeyword);
-      setFinalOption(() => sortOption);
-      currentPage.current = 0;
-      setList(() => []);
-      setIsFirstRender(true);
-      setIsLoadFinish(false);
-      setFinalMartCode(martCode.current);
-    }
-
-    // 처음 렌더가 되는 거라면 스크롤과 상관 없이 상품을 가져온다.
-    if (isFirstRender) {
-      getList();
-      setIsFirstRender(false);
-    }
-
-    return () => {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      listComponent?.current?.removeEventListener("scroll", handleScroll);
-    };
-  }, [
-    dispatch,
-    isFirstRender,
-    isLoadFinish,
-    lastPage,
-    list,
-    finalKeyword,
-    sortOption,
+  const [list, getList, isSpinnerActive, isLoadFinish] = useLoadData({
     searchKeyword,
-    setFinalKeyword,
-    finalOption,
-    finalMartCode,
     martList,
-  ]);
-
-  // setMartCode before render
-  useLayoutEffect(() => {
-    martCode.current = getMartCode(martList);
-    setFinalMartCode(martCode.current);
-    currentPage.current = 0;
-  }, [martCode, martList]);
+    sortOption,
+  });
+  const [listRef] = useInfiniteScroll({ isLoadFinish, getList });
 
   return (
     <ProductListPresenter
       list={list}
-      listComponent={listComponent}
-      isLoading={isLoading}
+      listComponent={listRef}
+      isSpinnerActive={isSpinnerActive}
     />
   );
 };

--- a/frontend/src/Components/ProductList/ProductListPresenter.js
+++ b/frontend/src/Components/ProductList/ProductListPresenter.js
@@ -3,15 +3,15 @@ import React from "react";
 import Product from "../Product";
 import Loading from "../Loading";
 
-const ProductListPresenter = ({ list, listComponent, isLoading }) => {
+const ProductListPresenter = ({ list, listComponent, isSpinnerActive }) => {
   return (
     <main className="product-list-container-container">
       <div className="product-list-container" ref={listComponent}>
         <div className="product-list">
-          {list.map((item) => {
+          {list.map((item, idx) => {
             return (
               <Product
-                key={item.productId}
+                key={idx}
                 id={item.productId}
                 mart_name={item.martName}
                 product_name={item.productName}
@@ -23,7 +23,7 @@ const ProductListPresenter = ({ list, listComponent, isLoading }) => {
           })}
         </div>
       </div>
-      {isLoading && <Loading />}
+      {isSpinnerActive && <Loading />}
     </main>
   );
 };

--- a/frontend/src/Components/Util/Constant.js
+++ b/frontend/src/Components/Util/Constant.js
@@ -20,3 +20,8 @@ export const PURCHASE_OPTION = Object.freeze({
   TIMEOVER_PURCHASE: 2,
   DELETE_PURCHASE: 100,
 });
+
+export const SORT_OPTION = Object.freeze({
+  PRODUCT_NAME: 0,
+  SALE_PRICE: 1,
+});

--- a/frontend/src/Pages/MyBagPage.js
+++ b/frontend/src/Pages/MyBagPage.js
@@ -10,7 +10,7 @@ import Layout from "../Components/Layout";
 import "../scss/MyBagPage.scss";
 import HelmetComponent from "../Components/HelmetComponent";
 import { PURCHASE_OPTION } from "../Components/Util/Constant";
-import useSetMyBagList from "../Components/Util/useSetMyBagList";
+import useSetMyBagList from "../Components/Hook/useSetMyBagList";
 import addComma from "../Components/Util/AddComma";
 
 const LogoLong = () => {

--- a/frontend/src/scss/ProductList.scss
+++ b/frontend/src/scss/ProductList.scss
@@ -52,6 +52,7 @@
     position: relative;
     overflow: hidden;
     margin-top: -1rem; // negative margin
+    height: 100%;
   }
   @include mobile {
     position: relative;

--- a/frontend/src/scss/components/_detail.scss
+++ b/frontend/src/scss/components/_detail.scss
@@ -22,6 +22,10 @@
         width: 100%;
         max-height: 14em;
       }
+
+      @include desktop {
+        max-height: 25em;
+      }
     }
   }
 


### PR DESCRIPTION
## 작업 내용

- [x] `ProductList`에서 사용하던 인피니티 스크롤을 `useLoadData`, `useInfiniteScroll` 커스텀 훅을 이용해서 코드의 가독성을 높였습니다!
- [x] (Desktop) 스피너가 첫 로딩일 때 짤리던 현상을 해결했습니다.
- [x] (Desktop) 상세페이지에서 이미지가 깨지는 것을 해결했습니다.

## 전달 사항

BagProduct를 Product로 바꾸려고 했는데, 이게 쉽지 않네요 ㅠㅠ (될지 안될지 잘 모르겠어요 !!! ㅠ)

추후에 우선적으로 BagProduct도 `grid-template`에서 `flex`로만 바꾸겠습니다!
