### PR TITLE
상품 리스트 페이지 UX 개선

### DIFF
--- a/frontend/src/Components/Layout/LayoutContainer.js
+++ b/frontend/src/Components/Layout/LayoutContainer.js
@@ -6,7 +6,7 @@ import LayoutPresenter from "./LayoutPresenter";
 
 const LayoutContainer = ({ children }) => {
   const pathname = useLocation().pathname;
-  const [showSideMenu, setShowSideMenu] = useState(false);
+  const [showSideMenu, setShowSideMenu] = useState(!detectMobile());
   const [isRequiredBackBtn, setIsRequiredBackBtn] = useState(true);
   const [isRequiredSideMenuBtn, setIsRequiredSideMenuBtn] = useState(true);
 

--- a/frontend/src/Components/Layout/SideMenuBtn/SideMenuBtnContainer.js
+++ b/frontend/src/Components/Layout/SideMenuBtn/SideMenuBtnContainer.js
@@ -19,7 +19,6 @@ const SideMenuBtnContainer = ({ showSideMenu, setShowSideMenu }) => {
   useLayoutEffect(() => {
     const isMobile = detectMobile();
     if (!isMobile) {
-      setShowSideMenu(true);
       dispatch(openedSideMenu(true));
     }
   }, [dispatch, setShowSideMenu]);

--- a/frontend/src/scss/ProductList.scss
+++ b/frontend/src/scss/ProductList.scss
@@ -14,10 +14,10 @@
   width: 100%;
   flex-direction: column;
   @include desktop {
-    flex-wrap: wrap;
-    flex-direction: row;
-    width: calc(100% - 2rem);
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 12rem);
     justify-content: space-evenly;
+    width: calc(100% - 2rem);
     gap: 1rem;
     padding: 1rem;
   }


### PR DESCRIPTION
## 작업 내용

- [x] flex => grid로 다시 변경
- [x] 사이드메뉴 애니메이션 UX 개선

## 전달 사항

- `grid`의 `auto-fill`을 적용해 원하던 것을 이루었습니다. ~~ie는 훠이~~
- 사이드 메뉴가 상품 리스트 페이지와 장바구니 페이지에 접속할 때마다 열리는 애니메이션이 나오는 것을 없앴습니다.
  - `showSideMenu`의 기본 값이 `false`여서 모바일인지 검사한 후 `true`로 바꾸는 로직 때문에 발생한 문제입니다.
